### PR TITLE
docs(contexts): add context pair reference docs

### DIFF
--- a/docs/contexts/AlertProvider.md
+++ b/docs/contexts/AlertProvider.md
@@ -1,0 +1,90 @@
+# AlertProvider / useAlert
+
+> 🇮🇹 [Italiano](../it/contexts/AlertProvider.md) | 🇪🇸 [Español](../es/contexts/AlertProvider.md)
+
+## Overview
+
+`AlertProvider` manages in-app notifications. On desktop it renders a banner alert component; on mobile/tablet it uses Sileo toast notifications (when `sileoToastEnabled: true` in config). Four severity types are supported: `danger`, `info`, `success`, `warning`.
+
+---
+
+## Setup
+
+Place `AlertProvider` inside `ConfigProvider` (it reads `sileoToastEnabled` and `customDeviceType` from config).
+
+```jsx
+import { ConfigProvider, AlertProvider } from 'thecore-auth';
+
+function App() {
+  return (
+    <ConfigProvider>
+      <AlertProvider>
+        {/* your app */}
+      </AlertProvider>
+    </ConfigProvider>
+  );
+}
+```
+
+To display the alert banner, render the `Alert` component (from `thecore-auth`) somewhere in your layout — typically at the top level inside `AlertProvider`.
+
+---
+
+## Hook API
+
+```js
+const alert = useAlert();
+```
+
+| Value | Type | Description |
+|---|---|---|
+| `showAlert` | `boolean` | Whether the alert banner is currently visible |
+| `setShowAlert` | `(value: boolean) => void` | Manually show or hide the alert banner |
+| `typeAlert` | `'danger' \| 'info' \| 'success' \| 'warning'` | Current alert severity |
+| `setTypeAlert` | `(type: string) => void` | Override the alert type directly |
+| `messageAlert` | `string` | Current alert message text |
+| `setMessageAlert` | `(message: string) => void` | Override the message directly |
+| `alertConfig` | `Record<string, object>` | Tailwind class maps for each alert type (colors, hover, ring, progress) |
+| `getIcon` | `(type: string) => ReactElement` | Returns the icon component for the given alert type |
+| `closeAlert` | `() => void` | Toggles `showAlert` to close the banner |
+| `activeAlert` | `(type, message, customType?) => void` | Triggers an alert — uses Sileo toast on mobile/tablet, banner on desktop |
+
+### `activeAlert` parameters
+
+| Parameter | Type | Description |
+|---|---|---|
+| `type` | `'danger' \| 'info' \| 'success' \| 'warning'` | Alert severity |
+| `message` | `string` | The text to display |
+| `customType` | `any` (optional) | When truthy, forces the banner even on mobile (bypasses Sileo) |
+
+---
+
+## Usage
+
+```jsx
+import { useAlert } from 'thecore-auth';
+
+function DeleteButton({ onDelete }) {
+  const { activeAlert } = useAlert();
+
+  const handleDelete = async () => {
+    try {
+      await onDelete();
+      activeAlert('success', 'Item deleted successfully');
+    } catch {
+      activeAlert('danger', 'Could not delete the item');
+    }
+  };
+
+  return <button onClick={handleDelete}>Delete</button>;
+}
+```
+
+---
+
+## Notes
+
+- On mobile and tablet, when `sileoToastEnabled: true`, `activeAlert` dispatches a Sileo toast and returns immediately — `showAlert` is never set to `true` in this path.
+- `customDeviceType` in config overrides the automatically detected device type. Useful for forcing desktop behavior in hybrid environments.
+- `activeAlert` resets `showAlert` to `false` before setting the new alert (via a 50 ms `setTimeout`) to force a re-render even when the same message is triggered twice in a row.
+- `closeAlert` toggles the value (does not unconditionally set to `false`) — avoid calling it when `showAlert` is already `false`.

--- a/docs/contexts/AuthProvider.md
+++ b/docs/contexts/AuthProvider.md
@@ -1,0 +1,101 @@
+# AuthProvider / useAuth
+
+> 🇮🇹 [Italiano](../it/contexts/AuthProvider.md) | 🇪🇸 [Español](../es/contexts/AuthProvider.md)
+
+## Overview
+
+`AuthProvider` is the central authentication context for `thecore-auth`. It manages the JWT session lifecycle: login, logout, token expiry, heartbeat renewal, and auto-login with a backend token. It depends on `ConfigProvider`, `LoadingProvider`, and `AlertProvider`.
+
+---
+
+## Setup
+
+Place `AuthProvider` inside `ConfigProvider`, `LoadingProvider`, and `AlertProvider`, and inside a React Router context (it calls `useNavigate` internally). When you use `PackageRoutes`, the correct nesting is already handled for you.
+
+```jsx
+import { BrowserRouter } from 'react-router-dom';
+import {
+  ConfigProvider,
+  AlertProvider,
+  LoadingProvider,
+  AuthProvider,
+} from 'thecore-auth';
+
+function App() {
+  return (
+    <BrowserRouter>
+      <ConfigProvider>
+        <AlertProvider>
+          <LoadingProvider>
+            <AuthProvider>
+              {/* your app */}
+            </AuthProvider>
+          </LoadingProvider>
+        </AlertProvider>
+      </ConfigProvider>
+    </BrowserRouter>
+  );
+}
+```
+
+---
+
+## Hook API
+
+```js
+const auth = useAuth();
+```
+
+| Value | Type | Description |
+|---|---|---|
+| `isAuthenticated` | `boolean \| null` | `null` during initial check, `true` when authenticated, `false` otherwise |
+| `setIsAuthenticated` | `(value: boolean) => void` | Override authentication state directly |
+| `autoLoginError` | `Error \| null` | Set when auto-login with `backendToken` fails |
+| `login` | `(e?: Event, formData: object) => Promise<void>` | Submit credentials; navigates to `firstPrivatePath` on success |
+| `logout` | `() => void` | Clears storage and sets `isAuthenticated` to `false` |
+| `createAxiosInstances` | `(onUnauthorized?, onNotFound?, onGenericError?) => Promise<AxiosInstance>` | Returns a configured Axios instance with error interceptors |
+| `fetchHeartbeat` | `() => Promise<void>` | Calls the heartbeat endpoint and refreshes the token |
+| `getTokenExpiry` | `(token?: string) => number \| undefined` | Decodes the JWT and returns milliseconds until expiry minus `timeDeducted` |
+| `checkTokenValidity` | `(token: string) => boolean` | Returns `true` if the token is present and not expired |
+| `fetchUser` | `(token: string) => Promise<void>` | Fetches user data with the provided token (used for auto-login) |
+| `handleLoad` | `() => void` | Validates the stored token on page reload |
+
+---
+
+## Usage
+
+```jsx
+import { useAuth } from 'thecore-auth';
+
+function Dashboard() {
+  const { isAuthenticated, logout, createAxiosInstances } = useAuth();
+
+  const fetchData = async () => {
+    // createAxiosInstances returns an Axios instance pre-configured
+    // with authorization headers and error interceptors
+    const axios = await createAxiosInstances();
+    const res = await axios.get('/api/data');
+    console.log(res.data);
+  };
+
+  if (isAuthenticated === null) return <p>Loading...</p>;
+  if (!isAuthenticated) return <p>Not authenticated</p>;
+
+  return (
+    <div>
+      <button onClick={fetchData}>Fetch data</button>
+      <button onClick={logout}>Logout</button>
+    </div>
+  );
+}
+```
+
+---
+
+## Notes
+
+- `isAuthenticated` starts as `null` (not `false`) to distinguish "not yet checked" from "checked and unauthenticated". Guard against `null` before rendering protected UI.
+- Auto-login is triggered when `autoLogin: true` in `config.json` and `isAuthenticated` is `false`. The `backendToken` must be set in config.
+- When `infiniteSession: true`, `fetchHeartbeat` is called on an interval before the token expires to obtain a fresh token without re-login.
+- When `autoLoginError` is set (auto-login failed), the auto-login effect will not retry — render `DefaultAutoLoginFallback` or a custom fallback page.
+- `createAxiosInstances` accepts optional callbacks: `onUnauthorized` defaults to `logout`.

--- a/docs/contexts/ConfigProvider.md
+++ b/docs/contexts/ConfigProvider.md
@@ -1,0 +1,116 @@
+# ConfigProvider / useConfig
+
+> 🇮🇹 [Italiano](../it/contexts/ConfigProvider.md) | 🇪🇸 [Español](../es/contexts/ConfigProvider.md)
+
+## Overview
+
+`ConfigProvider` reads `public/config.json` at runtime and makes every key available throughout the app via `useConfig()`. It also injects utility functions for IndexedDB access, date formatting, and session-key generation. If the file cannot be fetched, it renders an `ErrorPage` with a configuration template.
+
+---
+
+## Setup
+
+Place `ConfigProvider` at the root of your tree, wrapping all other providers.
+
+```jsx
+import { ConfigProvider } from 'thecore-auth';
+
+function App() {
+  return (
+    <ConfigProvider>
+      {/* all other providers and your app go here */}
+    </ConfigProvider>
+  );
+}
+```
+
+`public/config.json` must exist. Minimum example:
+
+```json
+{
+  "baseUri": "https://api.example.com",
+  "authenticatedEndpoint": "/auth/login",
+  "usersEndpoint": "/users",
+  "heartbeatEndpoint": "/auth/heartbeat",
+  "firstPrivatePath": "/dashboard/",
+  "firstPrivateTitle": "Dashboard",
+  "infiniteSession": true,
+  "timeDeducted": 30000,
+  "alertTimeout": 5000,
+  "axiosTimeout": 10000,
+  "axiosErrors": {
+    "unauthorized": "Session expired",
+    "notFound": "Resource not found",
+    "defaultMessage": "An error occurred"
+  },
+  "clearLoginFormOnError": true,
+  "autoLogin": false,
+  "backendToken": "",
+  "isDebug": false,
+  "showHeaderButton": true,
+  "stopLoaderOnFinish": true
+}
+```
+
+---
+
+## Hook API
+
+```js
+const config = useConfig();
+```
+
+All keys from `config.json` are available directly. In addition, `ConfigProvider` injects:
+
+| Value | Type | Description |
+|---|---|---|
+| `version` | `string` | Package version read from `package.json` (or `/package.json` in production) |
+| `sessionKey` | `string \| null` | Unique session key stored in `sessionStorage`; `null` if `hasSessionKey` is falsy |
+| `activity` | `object` | User-activity signals from `useUserActivity` (internal hook) |
+| `setCurrentDate` | `() => string` | Returns current date/time formatted as `"dd/mm/yyyy hh:mm:ss"` |
+| `openIndexedDB` | `(dbName, storeName) => Promise<IDBDatabase>` | Opens (or creates) an IndexedDB database |
+| `getDataIndexedDB` | `(dbName, storeName, key) => Promise<any>` | Reads a record by key from an IndexedDB store |
+| `setDataIndexedDB` | `(dbName, storeName, data) => Promise<void>` | Writes a record to an IndexedDB store (`data.id` required) |
+| `generateUniqueId` | `(dbName, storeName) => Promise<number>` | Returns a unique numeric ID not already present in the store |
+| `setDataWithAutoId` | `(dbName, storeName, data) => Promise<void>` | Writes a record, assigning an auto-generated ID if `data.id` is missing |
+
+---
+
+## Usage
+
+```jsx
+import { useConfig } from 'thecore-auth';
+
+function ApiExample() {
+  const {
+    baseUri,
+    heartbeatEndpoint,
+    isDebug,
+    setCurrentDate,
+    getDataIndexedDB,
+    setDataWithAutoId,
+  } = useConfig();
+
+  const saveRecord = async () => {
+    await setDataWithAutoId('myApp', 'logs', { message: 'Action taken' });
+    if (isDebug) console.log('[App]: record saved at', setCurrentDate());
+  };
+
+  return (
+    <div>
+      <p>API base: {baseUri}</p>
+      <p>Heartbeat: {heartbeatEndpoint}</p>
+      <button onClick={saveRecord}>Save log</button>
+    </div>
+  );
+}
+```
+
+---
+
+## Notes
+
+- `ConfigProvider` renders `ErrorPage` (not `null`) until the config is loaded. Children are never mounted with an empty config object.
+- `fetchConfig` is guarded by a `useRef` flag so it fires exactly once even in React Strict Mode.
+- In development (`isDevelopment: true` in config), the version is read from `package.json` at build time. In production it is fetched from `/package.json` at runtime.
+- `hasSessionKey: true` + optional `appKey` string generates a prefixed UUID stored in `sessionStorage`. The key persists for the browser tab's lifetime.

--- a/docs/contexts/LoadingProvider.md
+++ b/docs/contexts/LoadingProvider.md
@@ -1,0 +1,90 @@
+# LoadingProvider / useLoading
+
+> 🇮🇹 [Italiano](../it/contexts/LoadingProvider.md) | 🇪🇸 [Español](../es/contexts/LoadingProvider.md)
+
+## Overview
+
+`LoadingProvider` manages a global loading overlay. It exposes a boolean flag and helpers to show the loader immediately or for a fixed duration. The component rendered as the overlay can be replaced at runtime via `setLoadingComponent`.
+
+---
+
+## Setup
+
+Place `LoadingProvider` inside `ConfigProvider`. Pass your custom loading component as `defaultComponent` if you want to override the default loader.
+
+```jsx
+import { ConfigProvider, LoadingProvider } from 'thecore-auth';
+import MySpinner from './MySpinner';
+
+function App() {
+  return (
+    <ConfigProvider>
+      <LoadingProvider defaultComponent={<MySpinner />}>
+        {/* your app */}
+      </LoadingProvider>
+    </ConfigProvider>
+  );
+}
+```
+
+If `defaultComponent` is omitted, the library's built-in loader is used.
+
+---
+
+## Hook API
+
+```js
+const loading = useLoading();
+```
+
+| Value | Type | Description |
+|---|---|---|
+| `isLoading` | `boolean` | Whether the loading overlay is currently active |
+| `setIsLoading` | `(value: boolean) => void` | Directly set the loading state |
+| `loadingProps` | `object` | Props passed to the current loading component |
+| `setLoadingProps` | `(props: object) => void` | Update the loading component's props |
+| `loadingComponent` | `ReactElement \| undefined` | The component currently rendered as the loader |
+| `setLoadingComponent` | `(component: ReactElement) => void` | Replace the loader component at runtime |
+| `showLoadingFor` | `(duration?: number, props?: object) => void` | Show the loader for `duration` ms (default: 2000), then hide automatically |
+
+---
+
+## Usage
+
+```jsx
+import { useLoading } from 'thecore-auth';
+
+function SaveButton({ onSave }) {
+  const { isLoading, setIsLoading, showLoadingFor } = useLoading();
+
+  const handleSave = async () => {
+    setIsLoading(true);
+    try {
+      await onSave();
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleQuickAction = () => {
+    // Show loader for exactly 1.5 seconds regardless of when the action finishes
+    showLoadingFor(1500);
+    performQuickAction();
+  };
+
+  return (
+    <>
+      <button onClick={handleSave} disabled={isLoading}>Save</button>
+      <button onClick={handleQuickAction}>Quick action</button>
+    </>
+  );
+}
+```
+
+---
+
+## Notes
+
+- `showLoadingFor` uses `setTimeout` internally: after `duration` ms, `setIsLoading(false)` is called unconditionally. If you also call `setIsLoading(false)` manually before the timer fires, the timer will still fire but has no visible effect.
+- `loadingProps` is reset to `{}` on each `showLoadingFor` call (or to the `props` argument if provided).
+- The `LoadingProvider` accepts `children` and `defaultComponent` as props. `defaultComponent` sets the initial value of `loadingComponent` state.

--- a/docs/contexts/LoginFormProvider.md
+++ b/docs/contexts/LoginFormProvider.md
@@ -1,0 +1,133 @@
+# LoginFormProvider / useLoginForm
+
+> 🇮🇹 [Italiano](../it/contexts/LoginFormProvider.md) | 🇪🇸 [Español](../es/contexts/LoginFormProvider.md)
+
+## Overview
+
+`LoginFormProvider` manages the state of the login form: field values, labels, placeholder text, button copy, logo image, and card/logo styles. It wraps `AuthProvider`'s `login` function and optionally clears the form on error based on the `clearLoginFormOnError` config flag. It must be nested inside both `AuthProvider` and `ConfigProvider`.
+
+---
+
+## Setup
+
+Place `LoginFormProvider` inside `AuthProvider` and `ConfigProvider`.
+
+```jsx
+import {
+  ConfigProvider,
+  AlertProvider,
+  LoadingProvider,
+  AuthProvider,
+  LoginFormProvider,
+} from 'thecore-auth';
+
+function App() {
+  return (
+    <ConfigProvider>
+      <AlertProvider>
+        <LoadingProvider>
+          <AuthProvider>
+            <LoginFormProvider>
+              {/* login page components */}
+            </LoginFormProvider>
+          </AuthProvider>
+        </LoadingProvider>
+      </AlertProvider>
+    </ConfigProvider>
+  );
+}
+```
+
+---
+
+## Hook API
+
+```js
+const loginForm = useLoginForm();
+```
+
+| Value | Type | Description |
+|---|---|---|
+| `title` | `string` | Card title (default: `'Accedi'`) |
+| `setTitle` | `(value: string) => void` | Override the card title |
+| `label` | `string` | Input label (default: `'Email'`) |
+| `setLabel` | `(value: string) => void` | Override the input label |
+| `type` | `string` | Input type (default: `'email'`) |
+| `setType` | `(value: string) => void` | Override the input type (e.g. `'text'` for a username field) |
+| `placeholder` | `string` | Input placeholder (default: `'example@example.it'`) |
+| `setPlaceholder` | `(value: string) => void` | Override the placeholder |
+| `buttonText` | `string` | Submit button label (default: `'Accedi'`) |
+| `setButtonText` | `(value: string) => void` | Override the button label |
+| `formData` | `{ email: string, password: string }` | Controlled form values |
+| `setFormData` | `(data: object) => void` | Replace the entire form data object |
+| `changeData` | `(key: string, value: string) => void` | Update a single field in `formData` |
+| `handleLogin` | `(e: FormEvent) => void` | Calls `login(e, formData)` and optionally resets the form |
+| `LogoImg` | `ReactElement \| undefined` | Logo component rendered above the form card |
+| `setLogoImg` | `(component: ReactElement) => void` | Set the logo image/component |
+| `styleCardForm` | `object \| undefined` | Style overrides for the form card container |
+| `setStyleCardForm` | `(style: object) => void` | Set form card styles |
+| `styleContainerLogo` | `object \| undefined` | Style overrides for the logo container |
+| `setStyleContainerLogo` | `(style: object) => void` | Set logo container styles |
+| `styleLogo` | `object \| undefined` | Style overrides for the logo element |
+| `setStyleLogo` | `(style: object) => void` | Set logo element styles |
+| `overrideStyle` | `object` | Global style override object (default: `{}`) |
+| `setOverrideStyle` | `(style: object) => void` | Set global style overrides |
+| `customVersion` | `string \| null` | Custom version string displayed in the login card (default: `null`, shows package version) |
+| `setCustomVersion` | `(version: string \| null) => void` | Override the displayed version string |
+
+---
+
+## Usage
+
+```jsx
+import { useLoginForm } from 'thecore-auth';
+import { useEffect } from 'react';
+import MyLogo from './MyLogo';
+
+function CustomLoginPage() {
+  const {
+    setTitle,
+    setLabel,
+    setPlaceholder,
+    setButtonText,
+    setLogoImg,
+    handleLogin,
+    formData,
+    changeData,
+  } = useLoginForm();
+
+  useEffect(() => {
+    // Customize the login form appearance on mount
+    setTitle('Welcome back');
+    setLabel('Username');
+    setPlaceholder('your.username');
+    setButtonText('Sign in');
+    setLogoImg(<MyLogo />);
+  }, []);
+
+  return (
+    <form onSubmit={handleLogin}>
+      <label>{/* label rendered by LoginForm */}</label>
+      <input
+        value={formData.email}
+        onChange={e => changeData('email', e.target.value)}
+      />
+      <input
+        type="password"
+        value={formData.password}
+        onChange={e => changeData('password', e.target.value)}
+      />
+      <button type="submit">Sign in</button>
+    </form>
+  );
+}
+```
+
+---
+
+## Notes
+
+- `formData` uses the key `email` for the identifier field even when `type` is set to `'text'` — the key name does not change.
+- `handleLogin` calls `clearLoginFormOnError ? setFormData(initialData) : undefined` after calling `login`. The form reset is unconditional (it runs before the login resolves), because clearing on error alone would require coupling to the auth result.
+- `LoginForm` (the UI component) reads from this context automatically — mount it inside `LoginFormProvider` and it will be wired up with no extra props.
+- `SmartLogin` wraps `LoginFormProvider` internally; you do not need to add it yourself when using `SmartLogin`.

--- a/docs/contexts/ModalProvider.md
+++ b/docs/contexts/ModalProvider.md
@@ -1,0 +1,67 @@
+# ModalProvider / useModal
+
+> 🇮🇹 [Italiano](../it/contexts/ModalProvider.md) | 🇪🇸 [Español](../es/contexts/ModalProvider.md)
+
+## Overview
+
+`ModalProvider` manages a single, centralized modal dialog used throughout the application. It is controlled entirely through the `useModal()` hook — no prop drilling required.
+
+For the **full API reference** (variants, `openModal` options, style overrides, component slots, and examples), see [docs/modal.md](../modal.md).
+
+---
+
+## Setup
+
+`ModalProvider` must wrap any component that calls `useModal()`. When using `PackageRoutes` / `DefaultLayout`, it is already included. For manual setup:
+
+```jsx
+import { ModalProvider } from 'thecore-auth';
+
+function App() {
+  return (
+    <ModalProvider>
+      {/* your app */}
+    </ModalProvider>
+  );
+}
+```
+
+---
+
+## Hook API
+
+```js
+const modal = useModal();
+```
+
+| Value | Type | Description |
+|---|---|---|
+| `isOpen` | `boolean` | Whether the modal is currently visible |
+| `openModal` | `(options: OpenModalOptions) => void` | Open the modal with given configuration |
+| `closeModal` | `() => void` | Close the modal and reset all state |
+| `content` | `ReactElement \| null` | The component injected into `ModalMain` |
+| `title` | `string` | Modal title displayed in `ModalHeader` |
+| `type` | `'submit' \| 'delete' \| 'custom'` | Determines footer button layout |
+| `formId` | `string` | ID linking the footer's submit button to a form inside `ModalMain` |
+| `item` | `any` | Arbitrary data passed to the modal (e.g. the item being deleted) |
+| `style` | `object` | Style overrides for modal sections |
+| `modalData` | `object \| null` | Controlled form data managed inside the modal |
+| `setModalData` | `(data: object) => void` | Override `modalData` directly |
+| `handleChange` | `(e: ChangeEvent) => void` | Generic input change handler for `modalData` |
+| `handleSubmit` | `(e: FormEvent) => void` | Calls `onConfirm(modalData)` then closes the modal |
+| `headerContent` | `ReactElement \| null` | Custom header slot (replaces default `ModalHeader`) |
+| `setHeaderContent` | `(element: ReactElement) => void` | Set a custom header component |
+| `footerContent` | `ReactElement \| null` | Custom footer slot (replaces default `ModalFooter`) |
+| `setFooterContent` | `(element: ReactElement) => void` | Set a custom footer component |
+| `onCancel` | `() => void \| null` | Callback fired on cancel |
+| `setOnCancel` | `(fn: () => void) => void` | Set the cancel callback |
+
+See [docs/modal.md](../modal.md) for `OpenModalOptions` fields and detailed examples.
+
+---
+
+## Notes
+
+- All modal state is reset by `closeModal()` — title, content, formId, type, style, item, and modalData all return to their defaults.
+- The modal is designed to be opened from anywhere in the tree. You do not need to co-locate the trigger with the modal component.
+- For the full breakdown of `openModal` options and modal variants, refer to [docs/modal.md](../modal.md).

--- a/docs/contexts/RouteProvider.md
+++ b/docs/contexts/RouteProvider.md
@@ -1,0 +1,101 @@
+# RouteProvider / useRoutesInjection
+
+> 🇮🇹 [Italiano](../it/contexts/RouteProvider.md) | 🇪🇸 [Español](../es/contexts/RouteProvider.md)
+
+## Overview
+
+`RouteProvider` injects the host application's public and private routes into the `thecore-auth` routing system. It is the bridge between the library's `PackageRoutes` component and your app-specific route definitions. It accepts no configuration other than the two route arrays.
+
+---
+
+## Setup
+
+Wrap `PackageRoutes` (or any component that calls `useRoutesInjection`) with `RouteProvider` and pass your route arrays.
+
+```jsx
+import { RouteProvider, PackageRoutes } from 'thecore-auth';
+import PublicHomePage from './pages/PublicHomePage';
+import Dashboard from './pages/Dashboard';
+import Settings from './pages/Settings';
+
+const publicRoutes = [
+  { path: '/', element: <PublicHomePage /> },
+];
+
+const privateRoutes = [
+  { path: '/dashboard', element: <Dashboard /> },
+  { path: '/settings', element: <Settings /> },
+];
+
+function App() {
+  return (
+    <RouteProvider publicRoutes={publicRoutes} privateRoutes={privateRoutes}>
+      <PackageRoutes />
+    </RouteProvider>
+  );
+}
+```
+
+---
+
+## Props
+
+| Prop | Type | Default | Description |
+|---|---|---|---|
+| `publicRoutes` | `RouteObject[]` | `[]` | Routes accessible without authentication |
+| `privateRoutes` | `RouteObject[]` | `[]` | Routes protected by `AuthPage` middleware |
+
+Each entry in the arrays follows the same shape as React Router `RouteObject`:
+
+```js
+{ path: '/example', element: <MyPage />, title: 'Example' }
+```
+
+---
+
+## Hook API
+
+```js
+const { publicRoutes, privateRoutes } = useRoutesInjection();
+```
+
+| Value | Type | Description |
+|---|---|---|
+| `publicRoutes` | `RouteObject[]` | The public routes passed to `RouteProvider` |
+| `privateRoutes` | `RouteObject[]` | The private routes passed to `RouteProvider` |
+
+---
+
+## Usage
+
+```jsx
+import { useRoutesInjection } from 'thecore-auth';
+
+// Internal usage example (e.g. inside a custom router component)
+function MyCustomRouter() {
+  const { publicRoutes, privateRoutes } = useRoutesInjection();
+
+  return (
+    <Routes>
+      {publicRoutes.map(r => (
+        <Route key={r.path} path={r.path} element={r.element} />
+      ))}
+      {privateRoutes.map(r => (
+        <Route
+          key={r.path}
+          path={r.path}
+          element={<AuthPage>{r.element}</AuthPage>}
+        />
+      ))}
+    </Routes>
+  );
+}
+```
+
+---
+
+## Notes
+
+- `useRoutesInjection` throws a descriptive error if called outside `RouteProvider` — the error message includes the correct wrapping example.
+- `RouteProvider` performs no authentication logic; it only passes the arrays down via context. All auth guarding happens inside `PackageRoutes` and the `AuthPage` middleware.
+- Both `publicRoutes` and `privateRoutes` default to empty arrays so `PackageRoutes` renders safely even if one array is omitted.

--- a/docs/es/contexts/AlertProvider.md
+++ b/docs/es/contexts/AlertProvider.md
@@ -1,0 +1,90 @@
+# AlertProvider / useAlert
+
+> 🇬🇧 [English](../../contexts/AlertProvider.md) | 🇮🇹 [Italiano](../../it/contexts/AlertProvider.md)
+
+## Descripción general
+
+`AlertProvider` gestiona las notificaciones dentro de la aplicación. En escritorio renderiza un banner de alerta; en móvil/tablet usa notificaciones toast de Sileo (cuando `sileoToastEnabled: true` en config). Se admiten cuatro tipos de severidad: `danger`, `info`, `success`, `warning`.
+
+---
+
+## Configuración
+
+Colocar `AlertProvider` dentro de `ConfigProvider` (lee `sileoToastEnabled` y `customDeviceType` de config).
+
+```jsx
+import { ConfigProvider, AlertProvider } from 'thecore-auth';
+
+function App() {
+  return (
+    <ConfigProvider>
+      <AlertProvider>
+        {/* tu app */}
+      </AlertProvider>
+    </ConfigProvider>
+  );
+}
+```
+
+Para mostrar el banner de alerta, renderizar el componente `Alert` (de `thecore-auth`) en algún punto del layout — típicamente en el nivel superior dentro de `AlertProvider`.
+
+---
+
+## API del hook
+
+```js
+const alert = useAlert();
+```
+
+| Valor | Tipo | Descripción |
+|---|---|---|
+| `showAlert` | `boolean` | Si el banner de alerta está actualmente visible |
+| `setShowAlert` | `(value: boolean) => void` | Muestra u oculta manualmente el banner |
+| `typeAlert` | `'danger' \| 'info' \| 'success' \| 'warning'` | Severidad de la alerta actual |
+| `setTypeAlert` | `(type: string) => void` | Sobreescribe el tipo de alerta directamente |
+| `messageAlert` | `string` | Texto del mensaje de alerta actual |
+| `setMessageAlert` | `(message: string) => void` | Sobreescribe el mensaje directamente |
+| `alertConfig` | `Record<string, object>` | Mapas de clases Tailwind para cada tipo de alerta (colores, hover, ring, progress) |
+| `getIcon` | `(type: string) => ReactElement` | Devuelve el componente icono para el tipo de alerta dado |
+| `closeAlert` | `() => void` | Alterna `showAlert` para cerrar el banner |
+| `activeAlert` | `(type, message, customType?) => void` | Activa una alerta — usa toast Sileo en móvil/tablet, banner en escritorio |
+
+### Parámetros de `activeAlert`
+
+| Parámetro | Tipo | Descripción |
+|---|---|---|
+| `type` | `'danger' \| 'info' \| 'success' \| 'warning'` | Severidad de la alerta |
+| `message` | `string` | El texto a mostrar |
+| `customType` | `any` (opcional) | Si es truthy, fuerza el banner incluso en móvil (bypasa Sileo) |
+
+---
+
+## Uso
+
+```jsx
+import { useAlert } from 'thecore-auth';
+
+function DeleteButton({ onDelete }) {
+  const { activeAlert } = useAlert();
+
+  const handleDelete = async () => {
+    try {
+      await onDelete();
+      activeAlert('success', 'Elemento eliminado correctamente');
+    } catch {
+      activeAlert('danger', 'No se pudo eliminar el elemento');
+    }
+  };
+
+  return <button onClick={handleDelete}>Eliminar</button>;
+}
+```
+
+---
+
+## Notas
+
+- En móvil y tablet, cuando `sileoToastEnabled: true`, `activeAlert` envía un toast Sileo y retorna inmediatamente — `showAlert` nunca se establece a `true` en este flujo.
+- `customDeviceType` en config sobreescribe el tipo de dispositivo detectado automáticamente. Útil para forzar comportamiento de escritorio en entornos híbridos.
+- `activeAlert` resetea `showAlert` a `false` antes de establecer la nueva alerta (mediante un `setTimeout` de 50 ms) para forzar un re-render incluso cuando el mismo mensaje se activa dos veces seguidas.
+- `closeAlert` alterna el valor (no establece incondicionalmente a `false`) — evitar llamarlo cuando `showAlert` ya es `false`.

--- a/docs/es/contexts/AuthProvider.md
+++ b/docs/es/contexts/AuthProvider.md
@@ -1,0 +1,101 @@
+# AuthProvider / useAuth
+
+> 🇬🇧 [English](../../contexts/AuthProvider.md) | 🇮🇹 [Italiano](../../it/contexts/AuthProvider.md)
+
+## Descripción general
+
+`AuthProvider` es el contexto central de autenticación de `thecore-auth`. Gestiona el ciclo de vida de la sesión JWT: login, logout, expiración del token, renovación mediante heartbeat y auto-login con un token de backend. Depende de `ConfigProvider`, `LoadingProvider` y `AlertProvider`.
+
+---
+
+## Configuración
+
+Colocar `AuthProvider` dentro de `ConfigProvider`, `LoadingProvider` y `AlertProvider`, y dentro de un contexto de React Router (usa `useNavigate` internamente). Al usar `PackageRoutes`, el anidamiento correcto ya está gestionado.
+
+```jsx
+import { BrowserRouter } from 'react-router-dom';
+import {
+  ConfigProvider,
+  AlertProvider,
+  LoadingProvider,
+  AuthProvider,
+} from 'thecore-auth';
+
+function App() {
+  return (
+    <BrowserRouter>
+      <ConfigProvider>
+        <AlertProvider>
+          <LoadingProvider>
+            <AuthProvider>
+              {/* tu app */}
+            </AuthProvider>
+          </LoadingProvider>
+        </AlertProvider>
+      </ConfigProvider>
+    </BrowserRouter>
+  );
+}
+```
+
+---
+
+## API del hook
+
+```js
+const auth = useAuth();
+```
+
+| Valor | Tipo | Descripción |
+|---|---|---|
+| `isAuthenticated` | `boolean \| null` | `null` durante la comprobación inicial, `true` si autenticado, `false` en caso contrario |
+| `setIsAuthenticated` | `(value: boolean) => void` | Establece el estado de autenticación directamente |
+| `autoLoginError` | `Error \| null` | Se establece cuando el auto-login con `backendToken` falla |
+| `login` | `(e?: Event, formData: object) => Promise<void>` | Envía credenciales; navega a `firstPrivatePath` en caso de éxito |
+| `logout` | `() => void` | Limpia el almacenamiento y establece `isAuthenticated` a `false` |
+| `createAxiosInstances` | `(onUnauthorized?, onNotFound?, onGenericError?) => Promise<AxiosInstance>` | Devuelve una instancia Axios configurada con interceptores de error |
+| `fetchHeartbeat` | `() => Promise<void>` | Llama al endpoint heartbeat y renueva el token |
+| `getTokenExpiry` | `(token?: string) => number \| undefined` | Decodifica el JWT y devuelve los milisegundos hasta la expiración menos `timeDeducted` |
+| `checkTokenValidity` | `(token: string) => boolean` | Devuelve `true` si el token está presente y no ha expirado |
+| `fetchUser` | `(token: string) => Promise<void>` | Obtiene datos del usuario con el token proporcionado (usado para auto-login) |
+| `handleLoad` | `() => void` | Valida el token almacenado al recargar la página |
+
+---
+
+## Uso
+
+```jsx
+import { useAuth } from 'thecore-auth';
+
+function Dashboard() {
+  const { isAuthenticated, logout, createAxiosInstances } = useAuth();
+
+  const fetchData = async () => {
+    // createAxiosInstances devuelve una instancia Axios preconfigurada
+    // con cabeceras de autorización e interceptores de error
+    const axios = await createAxiosInstances();
+    const res = await axios.get('/api/data');
+    console.log(res.data);
+  };
+
+  if (isAuthenticated === null) return <p>Cargando...</p>;
+  if (!isAuthenticated) return <p>No autenticado</p>;
+
+  return (
+    <div>
+      <button onClick={fetchData}>Obtener datos</button>
+      <button onClick={logout}>Cerrar sesión</button>
+    </div>
+  );
+}
+```
+
+---
+
+## Notas
+
+- `isAuthenticated` comienza como `null` (no `false`) para distinguir "aún no comprobado" de "comprobado y no autenticado". Gestionar el caso `null` antes de renderizar UI protegida.
+- El auto-login se activa cuando `autoLogin: true` en `config.json` e `isAuthenticated` es `false`. El `backendToken` debe estar configurado en config.
+- Cuando `infiniteSession: true`, `fetchHeartbeat` se llama en intervalos antes de la expiración del token para obtener uno nuevo sin re-login.
+- Cuando `autoLoginError` está establecido (auto-login fallido), el efecto de auto-login no reintentará — renderizar `DefaultAutoLoginFallback` o una página de fallback personalizada.
+- `createAxiosInstances` acepta callbacks opcionales: `onUnauthorized` tiene como valor por defecto `logout`.

--- a/docs/es/contexts/ConfigProvider.md
+++ b/docs/es/contexts/ConfigProvider.md
@@ -1,0 +1,116 @@
+# ConfigProvider / useConfig
+
+> 🇬🇧 [English](../../contexts/ConfigProvider.md) | 🇮🇹 [Italiano](../../it/contexts/ConfigProvider.md)
+
+## Descripción general
+
+`ConfigProvider` lee `public/config.json` en tiempo de ejecución y pone a disposición cada clave en toda la aplicación a través de `useConfig()`. También inyecta funciones de utilidad para acceso a IndexedDB, formateo de fechas y generación de claves de sesión. Si el archivo no puede recuperarse, renderiza una `ErrorPage` con una plantilla de configuración.
+
+---
+
+## Configuración
+
+Colocar `ConfigProvider` en la raíz del árbol, envolviendo todos los demás providers.
+
+```jsx
+import { ConfigProvider } from 'thecore-auth';
+
+function App() {
+  return (
+    <ConfigProvider>
+      {/* todos los demás providers y tu app */}
+    </ConfigProvider>
+  );
+}
+```
+
+`public/config.json` debe existir. Ejemplo mínimo:
+
+```json
+{
+  "baseUri": "https://api.example.com",
+  "authenticatedEndpoint": "/auth/login",
+  "usersEndpoint": "/users",
+  "heartbeatEndpoint": "/auth/heartbeat",
+  "firstPrivatePath": "/dashboard/",
+  "firstPrivateTitle": "Dashboard",
+  "infiniteSession": true,
+  "timeDeducted": 30000,
+  "alertTimeout": 5000,
+  "axiosTimeout": 10000,
+  "axiosErrors": {
+    "unauthorized": "Sesión expirada",
+    "notFound": "Recurso no encontrado",
+    "defaultMessage": "Se ha producido un error"
+  },
+  "clearLoginFormOnError": true,
+  "autoLogin": false,
+  "backendToken": "",
+  "isDebug": false,
+  "showHeaderButton": true,
+  "stopLoaderOnFinish": true
+}
+```
+
+---
+
+## API del hook
+
+```js
+const config = useConfig();
+```
+
+Todas las claves de `config.json` están disponibles directamente. Además, `ConfigProvider` inyecta:
+
+| Valor | Tipo | Descripción |
+|---|---|---|
+| `version` | `string` | Versión del paquete leída desde `package.json` (o `/package.json` en producción) |
+| `sessionKey` | `string \| null` | Clave de sesión única almacenada en `sessionStorage`; `null` si `hasSessionKey` es falsy |
+| `activity` | `object` | Señales de actividad del usuario del hook interno `useUserActivity` |
+| `setCurrentDate` | `() => string` | Devuelve fecha/hora actual en formato `"dd/mm/yyyy hh:mm:ss"` |
+| `openIndexedDB` | `(dbName, storeName) => Promise<IDBDatabase>` | Abre (o crea) una base de datos IndexedDB |
+| `getDataIndexedDB` | `(dbName, storeName, key) => Promise<any>` | Lee un registro por clave de un store IndexedDB |
+| `setDataIndexedDB` | `(dbName, storeName, data) => Promise<void>` | Escribe un registro en un store IndexedDB (requiere `data.id`) |
+| `generateUniqueId` | `(dbName, storeName) => Promise<number>` | Devuelve un ID numérico único no presente aún en el store |
+| `setDataWithAutoId` | `(dbName, storeName, data) => Promise<void>` | Escribe un registro asignando un ID auto-generado si `data.id` falta |
+
+---
+
+## Uso
+
+```jsx
+import { useConfig } from 'thecore-auth';
+
+function ApiExample() {
+  const {
+    baseUri,
+    heartbeatEndpoint,
+    isDebug,
+    setCurrentDate,
+    getDataIndexedDB,
+    setDataWithAutoId,
+  } = useConfig();
+
+  const saveRecord = async () => {
+    await setDataWithAutoId('myApp', 'logs', { message: 'Acción realizada' });
+    if (isDebug) console.log('[App]: registro guardado a las', setCurrentDate());
+  };
+
+  return (
+    <div>
+      <p>API base: {baseUri}</p>
+      <p>Heartbeat: {heartbeatEndpoint}</p>
+      <button onClick={saveRecord}>Guardar log</button>
+    </div>
+  );
+}
+```
+
+---
+
+## Notas
+
+- `ConfigProvider` renderiza `ErrorPage` (no `null`) hasta que la configuración esté cargada. Los hijos nunca se montan con un objeto config vacío.
+- `fetchConfig` está protegido por un flag `useRef` que garantiza que se ejecuta exactamente una vez, incluso en React Strict Mode.
+- En desarrollo (`isDevelopment: true` en config), la versión se lee de `package.json` en tiempo de compilación. En producción se obtiene de `/package.json` en tiempo de ejecución.
+- `hasSessionKey: true` + cadena `appKey` opcional genera un UUID con prefijo almacenado en `sessionStorage`. La clave persiste durante toda la vida útil de la pestaña del navegador.

--- a/docs/es/contexts/LoadingProvider.md
+++ b/docs/es/contexts/LoadingProvider.md
@@ -1,0 +1,90 @@
+# LoadingProvider / useLoading
+
+> 🇬🇧 [English](../../contexts/LoadingProvider.md) | 🇮🇹 [Italiano](../../it/contexts/LoadingProvider.md)
+
+## Descripción general
+
+`LoadingProvider` gestiona un overlay de carga global. Expone un flag booleano y helpers para mostrar el loader inmediatamente o durante una duración fija. El componente renderizado como overlay puede reemplazarse en tiempo de ejecución mediante `setLoadingComponent`.
+
+---
+
+## Configuración
+
+Colocar `LoadingProvider` dentro de `ConfigProvider`. Pasar el componente de carga personalizado como `defaultComponent` si se desea sobreescribir el loader predeterminado.
+
+```jsx
+import { ConfigProvider, LoadingProvider } from 'thecore-auth';
+import MySpinner from './MySpinner';
+
+function App() {
+  return (
+    <ConfigProvider>
+      <LoadingProvider defaultComponent={<MySpinner />}>
+        {/* tu app */}
+      </LoadingProvider>
+    </ConfigProvider>
+  );
+}
+```
+
+Si se omite `defaultComponent`, se usa el loader integrado de la librería.
+
+---
+
+## API del hook
+
+```js
+const loading = useLoading();
+```
+
+| Valor | Tipo | Descripción |
+|---|---|---|
+| `isLoading` | `boolean` | Si el overlay de carga está actualmente activo |
+| `setIsLoading` | `(value: boolean) => void` | Establece directamente el estado de carga |
+| `loadingProps` | `object` | Props pasadas al componente de carga actual |
+| `setLoadingProps` | `(props: object) => void` | Actualiza las props del componente de carga |
+| `loadingComponent` | `ReactElement \| undefined` | El componente actualmente renderizado como loader |
+| `setLoadingComponent` | `(component: ReactElement) => void` | Reemplaza el componente loader en tiempo de ejecución |
+| `showLoadingFor` | `(duration?: number, props?: object) => void` | Muestra el loader durante `duration` ms (por defecto: 2000), luego se oculta automáticamente |
+
+---
+
+## Uso
+
+```jsx
+import { useLoading } from 'thecore-auth';
+
+function SaveButton({ onSave }) {
+  const { isLoading, setIsLoading, showLoadingFor } = useLoading();
+
+  const handleSave = async () => {
+    setIsLoading(true);
+    try {
+      await onSave();
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleQuickAction = () => {
+    // Muestra el loader durante exactamente 1.5 segundos
+    showLoadingFor(1500);
+    performQuickAction();
+  };
+
+  return (
+    <>
+      <button onClick={handleSave} disabled={isLoading}>Guardar</button>
+      <button onClick={handleQuickAction}>Acción rápida</button>
+    </>
+  );
+}
+```
+
+---
+
+## Notas
+
+- `showLoadingFor` usa `setTimeout` internamente: después de `duration` ms, `setIsLoading(false)` se llama incondicionalmente. Si se llama `setIsLoading(false)` manualmente antes de que el timer expire, el timer seguirá disparándose pero sin efecto visible.
+- `loadingProps` se resetea a `{}` en cada llamada a `showLoadingFor` (o al argumento `props` si se proporciona).
+- `LoadingProvider` acepta `children` y `defaultComponent` como props. `defaultComponent` establece el valor inicial del estado `loadingComponent`.

--- a/docs/es/contexts/LoginFormProvider.md
+++ b/docs/es/contexts/LoginFormProvider.md
@@ -1,0 +1,132 @@
+# LoginFormProvider / useLoginForm
+
+> 🇬🇧 [English](../../contexts/LoginFormProvider.md) | 🇮🇹 [Italiano](../../it/contexts/LoginFormProvider.md)
+
+## Descripción general
+
+`LoginFormProvider` gestiona el estado del formulario de login: valores de campos, etiquetas, placeholder, texto del botón, imagen de logo y estilos de la card/logo. Envuelve la función `login` de `AuthProvider` y, opcionalmente, limpia el formulario en caso de error según el flag `clearLoginFormOnError` en config. Debe anidarse dentro de `AuthProvider` y `ConfigProvider`.
+
+---
+
+## Configuración
+
+Colocar `LoginFormProvider` dentro de `AuthProvider` y `ConfigProvider`.
+
+```jsx
+import {
+  ConfigProvider,
+  AlertProvider,
+  LoadingProvider,
+  AuthProvider,
+  LoginFormProvider,
+} from 'thecore-auth';
+
+function App() {
+  return (
+    <ConfigProvider>
+      <AlertProvider>
+        <LoadingProvider>
+          <AuthProvider>
+            <LoginFormProvider>
+              {/* componentes de la página de login */}
+            </LoginFormProvider>
+          </AuthProvider>
+        </LoadingProvider>
+      </AlertProvider>
+    </ConfigProvider>
+  );
+}
+```
+
+---
+
+## API del hook
+
+```js
+const loginForm = useLoginForm();
+```
+
+| Valor | Tipo | Descripción |
+|---|---|---|
+| `title` | `string` | Título de la card (por defecto: `'Accedi'`) |
+| `setTitle` | `(value: string) => void` | Sobreescribe el título de la card |
+| `label` | `string` | Etiqueta del input (por defecto: `'Email'`) |
+| `setLabel` | `(value: string) => void` | Sobreescribe la etiqueta del input |
+| `type` | `string` | Tipo del input (por defecto: `'email'`) |
+| `setType` | `(value: string) => void` | Sobreescribe el tipo de input (ej. `'text'` para un campo username) |
+| `placeholder` | `string` | Placeholder del input (por defecto: `'example@example.it'`) |
+| `setPlaceholder` | `(value: string) => void` | Sobreescribe el placeholder |
+| `buttonText` | `string` | Etiqueta del botón de envío (por defecto: `'Accedi'`) |
+| `setButtonText` | `(value: string) => void` | Sobreescribe la etiqueta del botón |
+| `formData` | `{ email: string, password: string }` | Valores controlados del formulario |
+| `setFormData` | `(data: object) => void` | Reemplaza el objeto formData completo |
+| `changeData` | `(key: string, value: string) => void` | Actualiza un único campo en `formData` |
+| `handleLogin` | `(e: FormEvent) => void` | Llama a `login(e, formData)` y opcionalmente resetea el formulario |
+| `LogoImg` | `ReactElement \| undefined` | Componente logo renderizado sobre la card del formulario |
+| `setLogoImg` | `(component: ReactElement) => void` | Establece la imagen/componente logo |
+| `styleCardForm` | `object \| undefined` | Sobreescrituras de estilo para el contenedor de la card del formulario |
+| `setStyleCardForm` | `(style: object) => void` | Establece los estilos de la card del formulario |
+| `styleContainerLogo` | `object \| undefined` | Sobreescrituras de estilo para el contenedor del logo |
+| `setStyleContainerLogo` | `(style: object) => void` | Establece los estilos del contenedor del logo |
+| `styleLogo` | `object \| undefined` | Sobreescrituras de estilo para el elemento logo |
+| `setStyleLogo` | `(style: object) => void` | Establece los estilos del elemento logo |
+| `overrideStyle` | `object` | Objeto de sobreescritura global de estilos (por defecto: `{}`) |
+| `setOverrideStyle` | `(style: object) => void` | Establece las sobreescrituras globales de estilos |
+| `customVersion` | `string \| null` | Cadena de versión personalizada mostrada en la card (por defecto: `null`, muestra la versión del paquete) |
+| `setCustomVersion` | `(version: string \| null) => void` | Sobreescribe la cadena de versión mostrada |
+
+---
+
+## Uso
+
+```jsx
+import { useLoginForm } from 'thecore-auth';
+import { useEffect } from 'react';
+import MyLogo from './MyLogo';
+
+function CustomLoginPage() {
+  const {
+    setTitle,
+    setLabel,
+    setPlaceholder,
+    setButtonText,
+    setLogoImg,
+    handleLogin,
+    formData,
+    changeData,
+  } = useLoginForm();
+
+  useEffect(() => {
+    // Personalizar la apariencia del formulario de login al montar
+    setTitle('Bienvenido de nuevo');
+    setLabel('Nombre de usuario');
+    setPlaceholder('tu.usuario');
+    setButtonText('Iniciar sesión');
+    setLogoImg(<MyLogo />);
+  }, []);
+
+  return (
+    <form onSubmit={handleLogin}>
+      <input
+        value={formData.email}
+        onChange={e => changeData('email', e.target.value)}
+      />
+      <input
+        type="password"
+        value={formData.password}
+        onChange={e => changeData('password', e.target.value)}
+      />
+      <button type="submit">Iniciar sesión</button>
+    </form>
+  );
+}
+```
+
+---
+
+## Notas
+
+- `formData` usa la clave `email` para el campo identificador incluso cuando `type` se establece a `'text'` — el nombre de la clave no cambia.
+- `handleLogin` llama a `clearLoginFormOnError ? setFormData(initialData) : undefined` después de llamar a `login`. El reseteo del formulario es incondicional (ocurre antes de que el login se resuelva).
+- `LoginForm` (el componente UI) lee de este contexto automáticamente — montarlo dentro de `LoginFormProvider` es suficiente sin props adicionales.
+- `SmartLogin` incluye `LoginFormProvider` internamente; no es necesario añadirlo manualmente al usar `SmartLogin`.

--- a/docs/es/contexts/ModalProvider.md
+++ b/docs/es/contexts/ModalProvider.md
@@ -1,0 +1,67 @@
+# ModalProvider / useModal
+
+> 🇬🇧 [English](../../contexts/ModalProvider.md) | 🇮🇹 [Italiano](../../it/contexts/ModalProvider.md)
+
+## Descripción general
+
+`ModalProvider` gestiona un único diálogo modal centralizado usado en toda la aplicación. Se controla enteramente a través del hook `useModal()` — sin prop drilling.
+
+Para la **referencia API completa** (variantes, opciones de `openModal`, sobreescrituras de estilo, slots de componentes y ejemplos), ver [docs/modal.md](../../modal.md).
+
+---
+
+## Configuración
+
+`ModalProvider` debe envolver cualquier componente que llame a `useModal()`. Al usar `PackageRoutes` / `DefaultLayout`, ya está incluido. Para configuración manual:
+
+```jsx
+import { ModalProvider } from 'thecore-auth';
+
+function App() {
+  return (
+    <ModalProvider>
+      {/* tu app */}
+    </ModalProvider>
+  );
+}
+```
+
+---
+
+## API del hook
+
+```js
+const modal = useModal();
+```
+
+| Valor | Tipo | Descripción |
+|---|---|---|
+| `isOpen` | `boolean` | Si el modal está actualmente visible |
+| `openModal` | `(options: OpenModalOptions) => void` | Abre el modal con la configuración dada |
+| `closeModal` | `() => void` | Cierra el modal y resetea todo el estado |
+| `content` | `ReactElement \| null` | El componente inyectado en `ModalMain` |
+| `title` | `string` | Título del modal mostrado en `ModalHeader` |
+| `type` | `'submit' \| 'delete' \| 'custom'` | Determina el layout de los botones del footer |
+| `formId` | `string` | ID que conecta el botón submit del footer con un form dentro de `ModalMain` |
+| `item` | `any` | Datos arbitrarios pasados al modal (ej. el elemento a eliminar) |
+| `style` | `object` | Sobreescrituras de estilo para las secciones del modal |
+| `modalData` | `object \| null` | Datos de formulario controlado gestionados dentro del modal |
+| `setModalData` | `(data: object) => void` | Sobreescribe `modalData` directamente |
+| `handleChange` | `(e: ChangeEvent) => void` | Handler genérico para cambios de inputs en `modalData` |
+| `handleSubmit` | `(e: FormEvent) => void` | Llama a `onConfirm(modalData)` luego cierra el modal |
+| `headerContent` | `ReactElement \| null` | Slot de header personalizado (reemplaza el `ModalHeader` predeterminado) |
+| `setHeaderContent` | `(element: ReactElement) => void` | Establece un componente header personalizado |
+| `footerContent` | `ReactElement \| null` | Slot de footer personalizado (reemplaza el `ModalFooter` predeterminado) |
+| `setFooterContent` | `(element: ReactElement) => void` | Establece un componente footer personalizado |
+| `onCancel` | `() => void \| null` | Callback ejecutada al cancelar |
+| `setOnCancel` | `(fn: () => void) => void` | Establece la callback de cancelación |
+
+Para los campos de `OpenModalOptions` y ejemplos detallados, ver [docs/modal.md](../../modal.md).
+
+---
+
+## Notas
+
+- Todo el estado del modal es reseteado por `closeModal()` — título, contenido, formId, tipo, estilo, item y modalData vuelven a sus valores predeterminados.
+- El modal está diseñado para abrirse desde cualquier punto del árbol. No es necesario que el trigger esté cerca del componente modal.
+- Para el desglose completo de las opciones de `openModal` y las variantes del modal, ver [docs/modal.md](../../modal.md).

--- a/docs/es/contexts/RouteProvider.md
+++ b/docs/es/contexts/RouteProvider.md
@@ -1,0 +1,101 @@
+# RouteProvider / useRoutesInjection
+
+> 🇬🇧 [English](../../contexts/RouteProvider.md) | 🇮🇹 [Italiano](../../it/contexts/RouteProvider.md)
+
+## Descripción general
+
+`RouteProvider` inyecta las rutas públicas y privadas de la aplicación host en el sistema de routing de `thecore-auth`. Es el puente entre el componente `PackageRoutes` de la librería y las definiciones de rutas específicas de la app. No acepta más configuración que los dos arrays de rutas.
+
+---
+
+## Configuración
+
+Envolver `PackageRoutes` (o cualquier componente que llame a `useRoutesInjection`) con `RouteProvider` y pasar los arrays de rutas.
+
+```jsx
+import { RouteProvider, PackageRoutes } from 'thecore-auth';
+import PublicHomePage from './pages/PublicHomePage';
+import Dashboard from './pages/Dashboard';
+import Settings from './pages/Settings';
+
+const publicRoutes = [
+  { path: '/', element: <PublicHomePage /> },
+];
+
+const privateRoutes = [
+  { path: '/dashboard', element: <Dashboard /> },
+  { path: '/settings', element: <Settings /> },
+];
+
+function App() {
+  return (
+    <RouteProvider publicRoutes={publicRoutes} privateRoutes={privateRoutes}>
+      <PackageRoutes />
+    </RouteProvider>
+  );
+}
+```
+
+---
+
+## Props
+
+| Prop | Tipo | Por defecto | Descripción |
+|---|---|---|---|
+| `publicRoutes` | `RouteObject[]` | `[]` | Rutas accesibles sin autenticación |
+| `privateRoutes` | `RouteObject[]` | `[]` | Rutas protegidas por el middleware `AuthPage` |
+
+Cada entrada en los arrays sigue la misma estructura que `RouteObject` de React Router:
+
+```js
+{ path: '/ejemplo', element: <MiPagina />, title: 'Ejemplo' }
+```
+
+---
+
+## API del hook
+
+```js
+const { publicRoutes, privateRoutes } = useRoutesInjection();
+```
+
+| Valor | Tipo | Descripción |
+|---|---|---|
+| `publicRoutes` | `RouteObject[]` | Las rutas públicas pasadas a `RouteProvider` |
+| `privateRoutes` | `RouteObject[]` | Las rutas privadas pasadas a `RouteProvider` |
+
+---
+
+## Uso
+
+```jsx
+import { useRoutesInjection } from 'thecore-auth';
+
+// Ejemplo de uso interno (ej. dentro de un componente router personalizado)
+function MyCustomRouter() {
+  const { publicRoutes, privateRoutes } = useRoutesInjection();
+
+  return (
+    <Routes>
+      {publicRoutes.map(r => (
+        <Route key={r.path} path={r.path} element={r.element} />
+      ))}
+      {privateRoutes.map(r => (
+        <Route
+          key={r.path}
+          path={r.path}
+          element={<AuthPage>{r.element}</AuthPage>}
+        />
+      ))}
+    </Routes>
+  );
+}
+```
+
+---
+
+## Notas
+
+- `useRoutesInjection` lanza un error descriptivo si se llama fuera de `RouteProvider` — el mensaje incluye el ejemplo correcto de envoltura.
+- `RouteProvider` no realiza ninguna lógica de autenticación; solo pasa los arrays a través del contexto. Toda la protección de auth ocurre dentro de `PackageRoutes` y el middleware `AuthPage`.
+- Tanto `publicRoutes` como `privateRoutes` tienen arrays vacíos como valor por defecto, por lo que `PackageRoutes` renderiza sin errores incluso si se omite uno de los dos arrays.

--- a/docs/it/contexts/AlertProvider.md
+++ b/docs/it/contexts/AlertProvider.md
@@ -1,0 +1,90 @@
+# AlertProvider / useAlert
+
+> 🇬🇧 [English](../../contexts/AlertProvider.md) | 🇪🇸 [Español](../../es/contexts/AlertProvider.md)
+
+## Panoramica
+
+`AlertProvider` gestisce le notifiche in-app. Su desktop renderizza un banner di alert; su mobile/tablet usa le notifiche toast di Sileo (quando `sileoToastEnabled: true` nella config). Sono supportati quattro tipi di severità: `danger`, `info`, `success`, `warning`.
+
+---
+
+## Setup
+
+Inserire `AlertProvider` all'interno di `ConfigProvider` (legge `sileoToastEnabled` e `customDeviceType` dalla config).
+
+```jsx
+import { ConfigProvider, AlertProvider } from 'thecore-auth';
+
+function App() {
+  return (
+    <ConfigProvider>
+      <AlertProvider>
+        {/* la tua app */}
+      </AlertProvider>
+    </ConfigProvider>
+  );
+}
+```
+
+Per visualizzare il banner di alert, renderizzare il componente `Alert` (di `thecore-auth`) nel layout — tipicamente al livello superiore dentro `AlertProvider`.
+
+---
+
+## API dell'hook
+
+```js
+const alert = useAlert();
+```
+
+| Valore | Tipo | Descrizione |
+|---|---|---|
+| `showAlert` | `boolean` | Se il banner di alert è attualmente visibile |
+| `setShowAlert` | `(value: boolean) => void` | Mostra o nasconde manualmente il banner |
+| `typeAlert` | `'danger' \| 'info' \| 'success' \| 'warning'` | Severità dell'alert corrente |
+| `setTypeAlert` | `(type: string) => void` | Sovrascrive il tipo di alert direttamente |
+| `messageAlert` | `string` | Testo del messaggio di alert corrente |
+| `setMessageAlert` | `(message: string) => void` | Sovrascrive il messaggio direttamente |
+| `alertConfig` | `Record<string, object>` | Mappe di classi Tailwind per ogni tipo di alert (colori, hover, ring, progress) |
+| `getIcon` | `(type: string) => ReactElement` | Restituisce il componente icona per il tipo di alert dato |
+| `closeAlert` | `() => void` | Alterna `showAlert` per chiudere il banner |
+| `activeAlert` | `(type, message, customType?) => void` | Attiva un alert — usa il toast Sileo su mobile/tablet, il banner su desktop |
+
+### Parametri di `activeAlert`
+
+| Parametro | Tipo | Descrizione |
+|---|---|---|
+| `type` | `'danger' \| 'info' \| 'success' \| 'warning'` | Severità dell'alert |
+| `message` | `string` | Il testo da visualizzare |
+| `customType` | `any` (opzionale) | Se truthy, forza il banner anche su mobile (bypassa Sileo) |
+
+---
+
+## Utilizzo
+
+```jsx
+import { useAlert } from 'thecore-auth';
+
+function DeleteButton({ onDelete }) {
+  const { activeAlert } = useAlert();
+
+  const handleDelete = async () => {
+    try {
+      await onDelete();
+      activeAlert('success', 'Elemento eliminato con successo');
+    } catch {
+      activeAlert('danger', 'Impossibile eliminare l\'elemento');
+    }
+  };
+
+  return <button onClick={handleDelete}>Elimina</button>;
+}
+```
+
+---
+
+## Note
+
+- Su mobile e tablet, quando `sileoToastEnabled: true`, `activeAlert` invia un toast Sileo e ritorna immediatamente — `showAlert` non viene mai impostato a `true` in questo percorso.
+- `customDeviceType` nella config sovrascrive il tipo di dispositivo rilevato automaticamente. Utile per forzare il comportamento desktop in ambienti ibridi.
+- `activeAlert` azzera `showAlert` a `false` prima di impostare il nuovo alert (tramite un `setTimeout` da 50 ms) per forzare un re-render anche quando lo stesso messaggio viene attivato due volte di fila.
+- `closeAlert` alterna il valore (non imposta incondizionatamente a `false`) — evitare di chiamarlo quando `showAlert` è già `false`.

--- a/docs/it/contexts/AuthProvider.md
+++ b/docs/it/contexts/AuthProvider.md
@@ -1,0 +1,101 @@
+# AuthProvider / useAuth
+
+> 🇬🇧 [English](../../contexts/AuthProvider.md) | 🇪🇸 [Español](../../es/contexts/AuthProvider.md)
+
+## Panoramica
+
+`AuthProvider` è il contesto di autenticazione centrale di `thecore-auth`. Gestisce il ciclo di vita della sessione JWT: login, logout, scadenza del token, rinnovo tramite heartbeat e auto-login con un backend token. Dipende da `ConfigProvider`, `LoadingProvider` e `AlertProvider`.
+
+---
+
+## Setup
+
+Inserire `AuthProvider` all'interno di `ConfigProvider`, `LoadingProvider` e `AlertProvider`, e dentro un contesto React Router (usa `useNavigate` internamente). Usando `PackageRoutes`, l'annidamento corretto è già gestito.
+
+```jsx
+import { BrowserRouter } from 'react-router-dom';
+import {
+  ConfigProvider,
+  AlertProvider,
+  LoadingProvider,
+  AuthProvider,
+} from 'thecore-auth';
+
+function App() {
+  return (
+    <BrowserRouter>
+      <ConfigProvider>
+        <AlertProvider>
+          <LoadingProvider>
+            <AuthProvider>
+              {/* la tua app */}
+            </AuthProvider>
+          </LoadingProvider>
+        </AlertProvider>
+      </ConfigProvider>
+    </BrowserRouter>
+  );
+}
+```
+
+---
+
+## API dell'hook
+
+```js
+const auth = useAuth();
+```
+
+| Valore | Tipo | Descrizione |
+|---|---|---|
+| `isAuthenticated` | `boolean \| null` | `null` durante il controllo iniziale, `true` se autenticato, `false` altrimenti |
+| `setIsAuthenticated` | `(value: boolean) => void` | Imposta direttamente lo stato di autenticazione |
+| `autoLoginError` | `Error \| null` | Valorizzato quando l'auto-login con `backendToken` fallisce |
+| `login` | `(e?: Event, formData: object) => Promise<void>` | Invia le credenziali; in caso di successo naviga verso `firstPrivatePath` |
+| `logout` | `() => void` | Svuota lo storage e imposta `isAuthenticated` a `false` |
+| `createAxiosInstances` | `(onUnauthorized?, onNotFound?, onGenericError?) => Promise<AxiosInstance>` | Restituisce un'istanza Axios configurata con interceptor sugli errori |
+| `fetchHeartbeat` | `() => Promise<void>` | Chiama l'endpoint heartbeat e aggiorna il token |
+| `getTokenExpiry` | `(token?: string) => number \| undefined` | Decodifica il JWT e restituisce i millisecondi alla scadenza meno `timeDeducted` |
+| `checkTokenValidity` | `(token: string) => boolean` | Restituisce `true` se il token è presente e non scaduto |
+| `fetchUser` | `(token: string) => Promise<void>` | Recupera i dati utente con il token fornito (usato per l'auto-login) |
+| `handleLoad` | `() => void` | Valida il token memorizzato al ricaricamento della pagina |
+
+---
+
+## Utilizzo
+
+```jsx
+import { useAuth } from 'thecore-auth';
+
+function Dashboard() {
+  const { isAuthenticated, logout, createAxiosInstances } = useAuth();
+
+  const fetchData = async () => {
+    // createAxiosInstances restituisce un'istanza Axios preconfigurata
+    // con header di autorizzazione e interceptor sugli errori
+    const axios = await createAxiosInstances();
+    const res = await axios.get('/api/data');
+    console.log(res.data);
+  };
+
+  if (isAuthenticated === null) return <p>Caricamento...</p>;
+  if (!isAuthenticated) return <p>Non autenticato</p>;
+
+  return (
+    <div>
+      <button onClick={fetchData}>Recupera dati</button>
+      <button onClick={logout}>Logout</button>
+    </div>
+  );
+}
+```
+
+---
+
+## Note
+
+- `isAuthenticated` parte come `null` (non `false`) per distinguere "non ancora verificato" da "verificato e non autenticato". Gestire il caso `null` prima di mostrare UI protette.
+- L'auto-login viene attivato quando `autoLogin: true` in `config.json` e `isAuthenticated` è `false`. Il `backendToken` deve essere impostato nella config.
+- Quando `infiniteSession: true`, `fetchHeartbeat` viene chiamato a intervalli prima della scadenza del token per ottenerne uno nuovo senza re-login.
+- Quando `autoLoginError` è valorizzato (auto-login fallito), l'effetto di auto-login non ritenta — renderizzare `DefaultAutoLoginFallback` o una pagina di fallback personalizzata.
+- `createAxiosInstances` accetta callback opzionali: `onUnauthorized` ha come default `logout`.

--- a/docs/it/contexts/ConfigProvider.md
+++ b/docs/it/contexts/ConfigProvider.md
@@ -1,0 +1,116 @@
+# ConfigProvider / useConfig
+
+> 🇬🇧 [English](../../contexts/ConfigProvider.md) | 🇪🇸 [Español](../../es/contexts/ConfigProvider.md)
+
+## Panoramica
+
+`ConfigProvider` legge `public/config.json` a runtime e rende disponibile ogni chiave nell'intera applicazione tramite `useConfig()`. Inietta inoltre funzioni di utilità per accesso a IndexedDB, formattazione delle date e generazione della chiave di sessione. Se il file non può essere recuperato, renderizza una `ErrorPage` con un template di configurazione.
+
+---
+
+## Setup
+
+Inserire `ConfigProvider` alla radice dell'albero, avvolgendo tutti gli altri provider.
+
+```jsx
+import { ConfigProvider } from 'thecore-auth';
+
+function App() {
+  return (
+    <ConfigProvider>
+      {/* tutti gli altri provider e la tua app */}
+    </ConfigProvider>
+  );
+}
+```
+
+`public/config.json` deve esistere. Esempio minimo:
+
+```json
+{
+  "baseUri": "https://api.example.com",
+  "authenticatedEndpoint": "/auth/login",
+  "usersEndpoint": "/users",
+  "heartbeatEndpoint": "/auth/heartbeat",
+  "firstPrivatePath": "/dashboard/",
+  "firstPrivateTitle": "Dashboard",
+  "infiniteSession": true,
+  "timeDeducted": 30000,
+  "alertTimeout": 5000,
+  "axiosTimeout": 10000,
+  "axiosErrors": {
+    "unauthorized": "Sessione scaduta",
+    "notFound": "Risorsa non trovata",
+    "defaultMessage": "Si è verificato un errore"
+  },
+  "clearLoginFormOnError": true,
+  "autoLogin": false,
+  "backendToken": "",
+  "isDebug": false,
+  "showHeaderButton": true,
+  "stopLoaderOnFinish": true
+}
+```
+
+---
+
+## API dell'hook
+
+```js
+const config = useConfig();
+```
+
+Tutte le chiavi di `config.json` sono disponibili direttamente. In aggiunta, `ConfigProvider` inietta:
+
+| Valore | Tipo | Descrizione |
+|---|---|---|
+| `version` | `string` | Versione del pacchetto letta da `package.json` (o `/package.json` in produzione) |
+| `sessionKey` | `string \| null` | Chiave di sessione univoca memorizzata in `sessionStorage`; `null` se `hasSessionKey` è falsy |
+| `activity` | `object` | Segnali di attività utente dall'hook interno `useUserActivity` |
+| `setCurrentDate` | `() => string` | Restituisce data/ora corrente nel formato `"dd/mm/yyyy hh:mm:ss"` |
+| `openIndexedDB` | `(dbName, storeName) => Promise<IDBDatabase>` | Apre (o crea) un database IndexedDB |
+| `getDataIndexedDB` | `(dbName, storeName, key) => Promise<any>` | Legge un record per chiave da uno store IndexedDB |
+| `setDataIndexedDB` | `(dbName, storeName, data) => Promise<void>` | Scrive un record in uno store IndexedDB (richiede `data.id`) |
+| `generateUniqueId` | `(dbName, storeName) => Promise<number>` | Restituisce un ID numerico univoco non ancora presente nello store |
+| `setDataWithAutoId` | `(dbName, storeName, data) => Promise<void>` | Scrive un record assegnando un ID auto-generato se `data.id` è mancante |
+
+---
+
+## Utilizzo
+
+```jsx
+import { useConfig } from 'thecore-auth';
+
+function ApiExample() {
+  const {
+    baseUri,
+    heartbeatEndpoint,
+    isDebug,
+    setCurrentDate,
+    getDataIndexedDB,
+    setDataWithAutoId,
+  } = useConfig();
+
+  const saveRecord = async () => {
+    await setDataWithAutoId('myApp', 'logs', { message: 'Azione eseguita' });
+    if (isDebug) console.log('[App]: record salvato alle', setCurrentDate());
+  };
+
+  return (
+    <div>
+      <p>API base: {baseUri}</p>
+      <p>Heartbeat: {heartbeatEndpoint}</p>
+      <button onClick={saveRecord}>Salva log</button>
+    </div>
+  );
+}
+```
+
+---
+
+## Note
+
+- `ConfigProvider` renderizza `ErrorPage` (non `null`) finché la configurazione non è caricata. I figli non vengono mai montati con un oggetto config vuoto.
+- `fetchConfig` è protetto da un flag `useRef` che garantisce l'esecuzione esattamente una volta, anche in React Strict Mode.
+- In sviluppo (`isDevelopment: true` nella config), la versione è letta da `package.json` a build time. In produzione viene recuperata da `/package.json` a runtime.
+- `hasSessionKey: true` + stringa `appKey` opzionale genera un UUID prefissato memorizzato in `sessionStorage`. La chiave persiste per tutta la durata del tab del browser.

--- a/docs/it/contexts/LoadingProvider.md
+++ b/docs/it/contexts/LoadingProvider.md
@@ -1,0 +1,90 @@
+# LoadingProvider / useLoading
+
+> 🇬🇧 [English](../../contexts/LoadingProvider.md) | 🇪🇸 [Español](../../es/contexts/LoadingProvider.md)
+
+## Panoramica
+
+`LoadingProvider` gestisce un overlay di caricamento globale. Espone un flag booleano e helper per mostrare il loader immediatamente o per una durata fissa. Il componente renderizzato come overlay può essere sostituito a runtime tramite `setLoadingComponent`.
+
+---
+
+## Setup
+
+Inserire `LoadingProvider` all'interno di `ConfigProvider`. Passare il proprio componente di caricamento personalizzato come `defaultComponent` per sovrascrivere il loader predefinito.
+
+```jsx
+import { ConfigProvider, LoadingProvider } from 'thecore-auth';
+import MySpinner from './MySpinner';
+
+function App() {
+  return (
+    <ConfigProvider>
+      <LoadingProvider defaultComponent={<MySpinner />}>
+        {/* la tua app */}
+      </LoadingProvider>
+    </ConfigProvider>
+  );
+}
+```
+
+Se `defaultComponent` è omesso, viene usato il loader integrato nella libreria.
+
+---
+
+## API dell'hook
+
+```js
+const loading = useLoading();
+```
+
+| Valore | Tipo | Descrizione |
+|---|---|---|
+| `isLoading` | `boolean` | Se l'overlay di caricamento è attualmente attivo |
+| `setIsLoading` | `(value: boolean) => void` | Imposta direttamente lo stato di caricamento |
+| `loadingProps` | `object` | Props passate al componente di caricamento corrente |
+| `setLoadingProps` | `(props: object) => void` | Aggiorna le props del componente di caricamento |
+| `loadingComponent` | `ReactElement \| undefined` | Il componente attualmente renderizzato come loader |
+| `setLoadingComponent` | `(component: ReactElement) => void` | Sostituisce il componente loader a runtime |
+| `showLoadingFor` | `(duration?: number, props?: object) => void` | Mostra il loader per `duration` ms (default: 2000), poi lo nasconde automaticamente |
+
+---
+
+## Utilizzo
+
+```jsx
+import { useLoading } from 'thecore-auth';
+
+function SaveButton({ onSave }) {
+  const { isLoading, setIsLoading, showLoadingFor } = useLoading();
+
+  const handleSave = async () => {
+    setIsLoading(true);
+    try {
+      await onSave();
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleQuickAction = () => {
+    // Mostra il loader per esattamente 1.5 secondi
+    showLoadingFor(1500);
+    performQuickAction();
+  };
+
+  return (
+    <>
+      <button onClick={handleSave} disabled={isLoading}>Salva</button>
+      <button onClick={handleQuickAction}>Azione rapida</button>
+    </>
+  );
+}
+```
+
+---
+
+## Note
+
+- `showLoadingFor` usa `setTimeout` internamente: dopo `duration` ms, `setIsLoading(false)` viene chiamato incondizionatamente. Se si chiama `setIsLoading(false)` manualmente prima che il timer scada, il timer si attiverà comunque ma senza effetti visibili.
+- `loadingProps` viene azzerato a `{}` ad ogni chiamata di `showLoadingFor` (o impostato all'argomento `props` se fornito).
+- `LoadingProvider` accetta `children` e `defaultComponent` come props. `defaultComponent` imposta il valore iniziale dello stato `loadingComponent`.

--- a/docs/it/contexts/LoginFormProvider.md
+++ b/docs/it/contexts/LoginFormProvider.md
@@ -1,0 +1,132 @@
+# LoginFormProvider / useLoginForm
+
+> 🇬🇧 [English](../../contexts/LoginFormProvider.md) | 🇪🇸 [Español](../../es/contexts/LoginFormProvider.md)
+
+## Panoramica
+
+`LoginFormProvider` gestisce lo stato del form di login: valori dei campi, label, placeholder, testo del pulsante, immagine del logo e stili della card/logo. Avvolge la funzione `login` di `AuthProvider` e, facoltativamente, resetta il form in caso di errore in base al flag `clearLoginFormOnError` nella config. Deve essere annidato dentro `AuthProvider` e `ConfigProvider`.
+
+---
+
+## Setup
+
+Inserire `LoginFormProvider` all'interno di `AuthProvider` e `ConfigProvider`.
+
+```jsx
+import {
+  ConfigProvider,
+  AlertProvider,
+  LoadingProvider,
+  AuthProvider,
+  LoginFormProvider,
+} from 'thecore-auth';
+
+function App() {
+  return (
+    <ConfigProvider>
+      <AlertProvider>
+        <LoadingProvider>
+          <AuthProvider>
+            <LoginFormProvider>
+              {/* componenti della pagina di login */}
+            </LoginFormProvider>
+          </AuthProvider>
+        </LoadingProvider>
+      </AlertProvider>
+    </ConfigProvider>
+  );
+}
+```
+
+---
+
+## API dell'hook
+
+```js
+const loginForm = useLoginForm();
+```
+
+| Valore | Tipo | Descrizione |
+|---|---|---|
+| `title` | `string` | Titolo della card (default: `'Accedi'`) |
+| `setTitle` | `(value: string) => void` | Sovrascrive il titolo della card |
+| `label` | `string` | Label dell'input (default: `'Email'`) |
+| `setLabel` | `(value: string) => void` | Sovrascrive la label dell'input |
+| `type` | `string` | Tipo dell'input (default: `'email'`) |
+| `setType` | `(value: string) => void` | Sovrascrive il tipo di input (es. `'text'` per un campo username) |
+| `placeholder` | `string` | Placeholder dell'input (default: `'example@example.it'`) |
+| `setPlaceholder` | `(value: string) => void` | Sovrascrive il placeholder |
+| `buttonText` | `string` | Label del pulsante di invio (default: `'Accedi'`) |
+| `setButtonText` | `(value: string) => void` | Sovrascrive la label del pulsante |
+| `formData` | `{ email: string, password: string }` | Valori controllati del form |
+| `setFormData` | `(data: object) => void` | Sostituisce l'intero oggetto formData |
+| `changeData` | `(key: string, value: string) => void` | Aggiorna un singolo campo in `formData` |
+| `handleLogin` | `(e: FormEvent) => void` | Chiama `login(e, formData)` e facoltativamente resetta il form |
+| `LogoImg` | `ReactElement \| undefined` | Componente logo renderizzato sopra la card del form |
+| `setLogoImg` | `(component: ReactElement) => void` | Imposta l'immagine/componente logo |
+| `styleCardForm` | `object \| undefined` | Override di stile per il contenitore della card del form |
+| `setStyleCardForm` | `(style: object) => void` | Imposta gli stili della card del form |
+| `styleContainerLogo` | `object \| undefined` | Override di stile per il contenitore del logo |
+| `setStyleContainerLogo` | `(style: object) => void` | Imposta gli stili del contenitore del logo |
+| `styleLogo` | `object \| undefined` | Override di stile per l'elemento logo |
+| `setStyleLogo` | `(style: object) => void` | Imposta gli stili dell'elemento logo |
+| `overrideStyle` | `object` | Oggetto di override globale degli stili (default: `{}`) |
+| `setOverrideStyle` | `(style: object) => void` | Imposta gli override globali degli stili |
+| `customVersion` | `string \| null` | Stringa di versione personalizzata visualizzata nella card (default: `null`, mostra la versione del pacchetto) |
+| `setCustomVersion` | `(version: string \| null) => void` | Sovrascrive la stringa di versione visualizzata |
+
+---
+
+## Utilizzo
+
+```jsx
+import { useLoginForm } from 'thecore-auth';
+import { useEffect } from 'react';
+import MyLogo from './MyLogo';
+
+function CustomLoginPage() {
+  const {
+    setTitle,
+    setLabel,
+    setPlaceholder,
+    setButtonText,
+    setLogoImg,
+    handleLogin,
+    formData,
+    changeData,
+  } = useLoginForm();
+
+  useEffect(() => {
+    // Personalizza l'aspetto del form di login al mount
+    setTitle('Bentornato');
+    setLabel('Username');
+    setPlaceholder('tuo.username');
+    setButtonText('Accedi');
+    setLogoImg(<MyLogo />);
+  }, []);
+
+  return (
+    <form onSubmit={handleLogin}>
+      <input
+        value={formData.email}
+        onChange={e => changeData('email', e.target.value)}
+      />
+      <input
+        type="password"
+        value={formData.password}
+        onChange={e => changeData('password', e.target.value)}
+      />
+      <button type="submit">Accedi</button>
+    </form>
+  );
+}
+```
+
+---
+
+## Note
+
+- `formData` usa la chiave `email` per il campo identificatore anche quando `type` è impostato a `'text'` — il nome della chiave non cambia.
+- `handleLogin` chiama `clearLoginFormOnError ? setFormData(initialData) : undefined` dopo aver chiamato `login`. Il reset del form è incondizionale (avviene prima che il login si risolva).
+- `LoginForm` (il componente UI) legge da questo contesto automaticamente — montarlo dentro `LoginFormProvider` è sufficiente per cablarlo senza props aggiuntive.
+- `SmartLogin` include `LoginFormProvider` internamente; non è necessario aggiungerlo manualmente quando si usa `SmartLogin`.

--- a/docs/it/contexts/ModalProvider.md
+++ b/docs/it/contexts/ModalProvider.md
@@ -1,0 +1,67 @@
+# ModalProvider / useModal
+
+> 🇬🇧 [English](../../contexts/ModalProvider.md) | 🇪🇸 [Español](../../es/contexts/ModalProvider.md)
+
+## Panoramica
+
+`ModalProvider` gestisce un'unica finestra modale centralizzata, usata in tutta l'applicazione. È controllata interamente tramite l'hook `useModal()` — nessun prop drilling necessario.
+
+Per il **riferimento API completo** (varianti, opzioni di `openModal`, override di stile, slot dei componenti ed esempi), vedere [docs/modal.md](../../modal.md).
+
+---
+
+## Setup
+
+`ModalProvider` deve avvolgere qualsiasi componente che chiama `useModal()`. Usando `PackageRoutes` / `DefaultLayout`, è già incluso. Per setup manuale:
+
+```jsx
+import { ModalProvider } from 'thecore-auth';
+
+function App() {
+  return (
+    <ModalProvider>
+      {/* la tua app */}
+    </ModalProvider>
+  );
+}
+```
+
+---
+
+## API dell'hook
+
+```js
+const modal = useModal();
+```
+
+| Valore | Tipo | Descrizione |
+|---|---|---|
+| `isOpen` | `boolean` | Se la modale è attualmente visibile |
+| `openModal` | `(options: OpenModalOptions) => void` | Apre la modale con la configurazione data |
+| `closeModal` | `() => void` | Chiude la modale e azzera tutto lo stato |
+| `content` | `ReactElement \| null` | Il componente iniettato in `ModalMain` |
+| `title` | `string` | Titolo della modale visualizzato in `ModalHeader` |
+| `type` | `'submit' \| 'delete' \| 'custom'` | Determina il layout dei pulsanti nel footer |
+| `formId` | `string` | ID che collega il pulsante submit del footer a un form dentro `ModalMain` |
+| `item` | `any` | Dati arbitrari passati alla modale (es. l'elemento da eliminare) |
+| `style` | `object` | Override di stile per le sezioni della modale |
+| `modalData` | `object \| null` | Dati del form controllato gestiti dentro la modale |
+| `setModalData` | `(data: object) => void` | Sovrascrive `modalData` direttamente |
+| `handleChange` | `(e: ChangeEvent) => void` | Handler generico per i cambiamenti degli input in `modalData` |
+| `handleSubmit` | `(e: FormEvent) => void` | Chiama `onConfirm(modalData)` poi chiude la modale |
+| `headerContent` | `ReactElement \| null` | Slot header personalizzato (sostituisce il `ModalHeader` predefinito) |
+| `setHeaderContent` | `(element: ReactElement) => void` | Imposta un componente header personalizzato |
+| `footerContent` | `ReactElement \| null` | Slot footer personalizzato (sostituisce il `ModalFooter` predefinito) |
+| `setFooterContent` | `(element: ReactElement) => void` | Imposta un componente footer personalizzato |
+| `onCancel` | `() => void \| null` | Callback chiamata alla cancellazione |
+| `setOnCancel` | `(fn: () => void) => void` | Imposta la callback di cancellazione |
+
+Per i campi di `OpenModalOptions` ed esempi dettagliati, vedere [docs/modal.md](../../modal.md).
+
+---
+
+## Note
+
+- Tutto lo stato della modale viene resettato da `closeModal()` — titolo, contenuto, formId, tipo, stile, item e modalData tornano ai valori predefiniti.
+- La modale è progettata per essere aperta da qualsiasi punto dell'albero. Non è necessario che il trigger sia vicino al componente modale.
+- Per la descrizione completa delle opzioni di `openModal` e delle varianti della modale, vedere [docs/modal.md](../../modal.md).

--- a/docs/it/contexts/RouteProvider.md
+++ b/docs/it/contexts/RouteProvider.md
@@ -1,0 +1,101 @@
+# RouteProvider / useRoutesInjection
+
+> 🇬🇧 [English](../../contexts/RouteProvider.md) | 🇪🇸 [Español](../../es/contexts/RouteProvider.md)
+
+## Panoramica
+
+`RouteProvider` inietta le route pubbliche e private dell'applicazione host nel sistema di routing di `thecore-auth`. È il ponte tra il componente `PackageRoutes` della libreria e le definizioni di route specifiche dell'app. Non accetta altra configurazione oltre ai due array di route.
+
+---
+
+## Setup
+
+Avvolgere `PackageRoutes` (o qualsiasi componente che chiama `useRoutesInjection`) con `RouteProvider` e passare gli array di route.
+
+```jsx
+import { RouteProvider, PackageRoutes } from 'thecore-auth';
+import PublicHomePage from './pages/PublicHomePage';
+import Dashboard from './pages/Dashboard';
+import Settings from './pages/Settings';
+
+const publicRoutes = [
+  { path: '/', element: <PublicHomePage /> },
+];
+
+const privateRoutes = [
+  { path: '/dashboard', element: <Dashboard /> },
+  { path: '/settings', element: <Settings /> },
+];
+
+function App() {
+  return (
+    <RouteProvider publicRoutes={publicRoutes} privateRoutes={privateRoutes}>
+      <PackageRoutes />
+    </RouteProvider>
+  );
+}
+```
+
+---
+
+## Props
+
+| Prop | Tipo | Default | Descrizione |
+|---|---|---|---|
+| `publicRoutes` | `RouteObject[]` | `[]` | Route accessibili senza autenticazione |
+| `privateRoutes` | `RouteObject[]` | `[]` | Route protette dal middleware `AuthPage` |
+
+Ogni elemento degli array segue la stessa struttura di `RouteObject` di React Router:
+
+```js
+{ path: '/esempio', element: <MiaPagina />, title: 'Esempio' }
+```
+
+---
+
+## API dell'hook
+
+```js
+const { publicRoutes, privateRoutes } = useRoutesInjection();
+```
+
+| Valore | Tipo | Descrizione |
+|---|---|---|
+| `publicRoutes` | `RouteObject[]` | Le route pubbliche passate a `RouteProvider` |
+| `privateRoutes` | `RouteObject[]` | Le route private passate a `RouteProvider` |
+
+---
+
+## Utilizzo
+
+```jsx
+import { useRoutesInjection } from 'thecore-auth';
+
+// Esempio di utilizzo interno (es. dentro un componente router personalizzato)
+function MyCustomRouter() {
+  const { publicRoutes, privateRoutes } = useRoutesInjection();
+
+  return (
+    <Routes>
+      {publicRoutes.map(r => (
+        <Route key={r.path} path={r.path} element={r.element} />
+      ))}
+      {privateRoutes.map(r => (
+        <Route
+          key={r.path}
+          path={r.path}
+          element={<AuthPage>{r.element}</AuthPage>}
+        />
+      ))}
+    </Routes>
+  );
+}
+```
+
+---
+
+## Note
+
+- `useRoutesInjection` lancia un errore descrittivo se chiamato fuori da `RouteProvider` — il messaggio include l'esempio corretto di wrapping.
+- `RouteProvider` non esegue alcuna logica di autenticazione; si limita a passare gli array tramite contesto. Tutta la protezione auth avviene dentro `PackageRoutes` e il middleware `AuthPage`.
+- Sia `publicRoutes` che `privateRoutes` hanno come default array vuoti, quindi `PackageRoutes` renderizza senza errori anche se uno dei due array viene omesso.


### PR DESCRIPTION
## Summary

- Adds 21 Markdown reference files (7 EN + 7 IT + 7 ES) under `docs/contexts/`, `docs/it/contexts/`, `docs/es/contexts/`
- Documents all 7 context pairs: `AuthProvider/useAuth`, `ConfigProvider/useConfig`, `AlertProvider/useAlert`, `LoadingProvider/useLoading`, `ModalProvider/useModal`, `LoginFormProvider/useLoginForm`, `RouteProvider/useRoutesInjection`
- Each file follows the agreed schema: Overview → Setup → Hook API table → Usage (15-30 line example) → Notes
- `ModalProvider` file links to the existing `docs/modal.md` for the full API

## Test plan

- [ ] Check EN files render correctly on GitHub
- [ ] Verify IT/ES translations are consistent with EN content
- [ ] Confirm all cross-language links resolve correctly
- [ ] Spot-check Hook API tables against source files in `src/contexts/`

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)