### PR TITLE
docs(hooks): add standalone hooks reference docs

### DIFF
--- a/docs/es/hooks/UsePageTitle.md
+++ b/docs/es/hooks/UsePageTitle.md
@@ -1,0 +1,60 @@
+# UsePageTitle
+
+> [English](../../../docs/hooks/UsePageTitle.md) | [Versione italiana](../../it/hooks/UsePageTitle.md)
+
+## Descripción general
+
+`UsePageTitle` actualiza automáticamente `document.title` según la ruta actual. Compara la ruta activa con una lista de definiciones de rutas — incluyendo segmentos dinámicos como `/dashboard/:id` — y establece el título de la pestaña en consecuencia.
+
+## Importación
+
+```js
+import { UsePageTitle } from 'thecore-auth';
+```
+
+## Parámetros
+
+| Nombre | Tipo | Por defecto | Descripción |
+|--------|------|-------------|-------------|
+| `routes` | `Array<{ path: string, title: string }>` | `[]` | Definiciones de rutas que asocian un patrón de ruta a un título de página. Admite segmentos dinámicos de React Router. |
+| `defaultTitle` | `string` | `"SPOT"` | Título usado cuando ninguna ruta coincide con la ruta actual. |
+
+## Valor de retorno
+
+Este hook no devuelve nada (`void`). Funciona únicamente como efecto secundario.
+
+## Uso
+
+```jsx
+import { UsePageTitle } from 'thecore-auth';
+
+const PAGE_TITLES = [
+  { path: '/',               title: 'Inicio de sesión' },
+  { path: '/dashboard',      title: 'Panel de control' },
+  { path: '/dashboard/:id',  title: 'Detalle de tarea' },
+  { path: '/profile',        title: 'Mi perfil' },
+  { path: '/settings',       title: 'Configuración' },
+];
+
+function AppRoutes() {
+  // Sets document.title on every navigation, falls back to "SPOT"
+  UsePageTitle(PAGE_TITLES, 'SPOT');
+
+  return (
+    <Routes>
+      <Route path="/" element={<Login />} />
+      <Route path="/dashboard" element={<Dashboard />} />
+      <Route path="/dashboard/:id" element={<TaskDetail />} />
+      <Route path="/profile" element={<Profile />} />
+      <Route path="/settings" element={<Settings />} />
+    </Routes>
+  );
+}
+```
+
+## Notas
+
+- Debe llamarse dentro de un componente descendiente de `<BrowserRouter>` (o equivalente), ya que depende de `useLocation`.
+- Usa `matchPath` con `end: true`, por lo que `/dashboard` no coincide con `/dashboard/123`. Agregar entradas explícitas para los segmentos dinámicos cuando sea necesario.
+- La actualización ocurre dentro de `useLayoutEffect` para evitar un destello del título anterior durante la navegación.
+- El hook se exporta con `U` mayúscula (`UsePageTitle`) — esto es intencional y coincide con la convención de nomenclatura del código fuente.

--- a/docs/es/hooks/useAuthStorage.md
+++ b/docs/es/hooks/useAuthStorage.md
@@ -1,0 +1,63 @@
+# useAuthStorage
+
+> [English](../../../docs/hooks/useAuthStorage.md) | [Versione italiana](../../it/hooks/useAuthStorage.md)
+
+## Descripción general
+
+`useAuthStorage` gestiona los dos valores de autenticación almacenados en `localStorage` — el token de acceso y el objeto de usuario — a través de una interfaz unificada. Está construido sobre [`useStorage`](./useStorage.md) y es utilizado internamente por `AuthProvider`.
+
+## Importación
+
+```js
+import { useAuthStorage } from 'thecore-auth';
+```
+
+## Parámetros
+
+Este hook no acepta parámetros.
+
+## Valor de retorno
+
+| Clave | Tipo | Descripción |
+|-------|------|-------------|
+| `token` | `string | null` | Token JWT de acceso leído de la clave `localStorage` `"accessToken"`. |
+| `user` | `object | null` | Objeto de usuario leído de la clave `localStorage` `"user"`. |
+| `setToken` | `(value) => void` | Persiste un nuevo token de acceso en el estado y en `localStorage`. |
+| `setUser` | `(value) => void` | Persiste un nuevo objeto de usuario en el estado y en `localStorage`. |
+| `storageLogout` | `() => void` | Elimina tanto `"accessToken"` como `"user"` de `localStorage` y restablece el estado a `null`. |
+
+## Uso
+
+```jsx
+import { useAuthStorage } from 'thecore-auth';
+
+function SessionPanel() {
+  const { token, user, setToken, setUser, storageLogout } = useAuthStorage();
+
+  const handleLogin = (authResponse) => {
+    setToken(authResponse.accessToken);
+    setUser(authResponse.user);
+  };
+
+  const handleLogout = () => {
+    storageLogout(); // clears both token and user from localStorage
+  };
+
+  if (!token) {
+    return <button onClick={() => handleLogin({ accessToken: 'abc', user: { name: 'Alice' } })}>Iniciar sesión</button>;
+  }
+
+  return (
+    <div>
+      <p>Conectado como {user?.name}</p>
+      <button onClick={handleLogout}>Cerrar sesión</button>
+    </div>
+  );
+}
+```
+
+## Notas
+
+- `token` y `user` se inicializan desde `localStorage` en el primer render, por lo que la sesión sobrevive a los refrescos de página.
+- `storageLogout` llama a `removeToken()` y `removeUser()` individualmente; **no** llama a `localStorage.clear()`, por lo que las claves no relacionadas se conservan.
+- Preferir consumir el estado de autenticación a través de `useAuth` (el hook `AuthContext`) en lugar de llamar directamente a `useAuthStorage` — `AuthProvider` ya gestiona estos valores por ti.

--- a/docs/es/hooks/useCalendar.md
+++ b/docs/es/hooks/useCalendar.md
@@ -1,0 +1,78 @@
+# useCalendar
+
+> [English](../../../docs/hooks/useCalendar.md) | [Versione italiana](../../it/hooks/useCalendar.md)
+
+## Descripción general
+
+`useCalendar` proporciona datos de festivos y funciones de utilidad del calendario para un año y país determinados. Usa la librería [`date-holidays`](https://github.com/commenthol/date-holidays) para cargar la lista de festivos, expone un Map de búsqueda rápida y ofrece helpers para generar semanas, meses y rangos de fechas arbitrarios.
+
+## Importación
+
+```js
+import { useCalendar } from 'thecore-auth';
+```
+
+## Parámetros
+
+| Nombre | Tipo | Por defecto | Descripción |
+|--------|------|-------------|-------------|
+| `year` | `number` | año actual | El año para el que se cargan los festivos. |
+| `country` | `string` | `"IT"` | Código de país ISO 3166-1 alpha-2 usado por `date-holidays`. |
+
+## Valor de retorno
+
+| Clave | Tipo | Descripción |
+|-------|------|-------------|
+| `holidays` | `object[]` | Objetos de festivos sin procesar devueltos por `date-holidays` para el año configurado. |
+| `holidayMap` | `Map<string, object>` | Map con clave `"YYYY-MM-DD"` para búsqueda O(1) de festivos. |
+| `isTodayHoliday` | `() => boolean` | Devuelve `true` si hoy es un día festivo. |
+| `isHoliday` | `(date: Date \| string) => boolean` | Devuelve `true` si la fecha proporcionada es un día festivo. Acepta un objeto `Date` o una cadena en formato `"YYYY-MM-DD"` o `"DD/MM/YYYY"`. |
+| `getWeekDays` | `(date: Date \| string) => Date[]` | Devuelve un array de 7 objetos `Date` para la semana de lunes a domingo que contiene `date`. |
+| `getWeeksInMonth` | `(month: number, year?: number) => Date[][]` | Devuelve un array de semanas, cada una un `Date[]` de 7 elementos, que cubren el mes dado (indexado en 0). |
+| `getDaysInMonth` | `(month: number, year?: number) => Date[]` | Devuelve todos los días del mes dado como `Date[]`. |
+| `getDaysInMonths` | `(startMonth: number, startYear?: number, numMonths?: number) => Date[]` | Devuelve todos los días en `numMonths` meses consecutivos a partir de `startMonth`. |
+| `getDaysInYear` | `(year: number) => Date[]` | Devuelve los 365/366 días del año dado como `Date[]`. |
+
+## Uso
+
+```jsx
+import { useCalendar } from 'thecore-auth';
+
+function MonthView({ month, year }) {
+  const { getWeeksInMonth, isHoliday, isTodayHoliday } = useCalendar(year, 'IT');
+
+  const weeks = getWeeksInMonth(month, year);
+  const today = new Date().toDateString();
+
+  return (
+    <div>
+      {isTodayHoliday() && <p>¡Hoy es un día festivo!</p>}
+      {weeks.map((week, wi) => (
+        <div key={wi} style={{ display: 'flex' }}>
+          {week.map((day, di) => (
+            <div
+              key={di}
+              style={{
+                background: isHoliday(day) ? '#fdd' : day.toDateString() === today ? '#dfd' : '#fff',
+                border: '1px solid #ccc',
+                padding: '4px 8px',
+                minWidth: 36,
+                textAlign: 'center',
+              }}
+            >
+              {day.getDate()}
+            </div>
+          ))}
+        </div>
+      ))}
+    </div>
+  );
+}
+```
+
+## Notas
+
+- Los festivos se cargan de forma asíncrona dentro de un `useEffect`. El array `holidays` y `holidayMap` están vacíos en el primer render y se llenan una vez que el efecto se ejecuta. Protegerse contra esto si se renderiza inmediatamente al montarse.
+- `getDaysInMonths` maneja los cambios de año: comenzando desde el mes `10` con `numMonths = 6` se extiende correctamente al año siguiente.
+- `getWeeksInMonth` puede incluir días del mes anterior o posterior para completar las primeras y últimas semanas de la cuadrícula. Comprobar `day.getMonth() !== month` si se necesita ocultar los días fuera del mes.
+- Las claves de fecha en `holidayMap` se derivan de la hora local (no UTC), por lo que coinciden correctamente independientemente del desplazamiento de zona horaria del usuario.

--- a/docs/es/hooks/useClickOutside.md
+++ b/docs/es/hooks/useClickOutside.md
@@ -1,0 +1,69 @@
+# useClickOutside
+
+> [English](../../../docs/hooks/useClickOutside.md) | [Versione italiana](../../it/hooks/useClickOutside.md)
+
+## Descripción general
+
+`useClickOutside` llama a una callback cada vez que el usuario hace clic (o toca) fuera de un elemento DOM referenciado. Es el bloque de construcción estándar para cerrar menús desplegables, modales, popovers y menús contextuales al hacer clic fuera.
+
+## Importación
+
+```js
+import { useClickOutside } from 'thecore-auth';
+```
+
+## Parámetros
+
+| Nombre | Tipo | Por defecto | Descripción |
+|--------|------|-------------|-------------|
+| `ref` | `React.RefObject<HTMLElement>` | — | Ref adjunto al elemento que define el área "interior". |
+| `callback` | `() => void` | — | Función llamada cuando un evento `mousedown` ocurre fuera del elemento ref. |
+
+## Valor de retorno
+
+Este hook no devuelve nada (`void`). Funciona únicamente como efecto secundario.
+
+## Uso
+
+```jsx
+import { useRef } from 'react';
+import { useClickOutside } from 'thecore-auth';
+
+function Dropdown({ isOpen, onClose, children }) {
+  const ref = useRef(null);
+
+  // Close the dropdown whenever the user clicks outside
+  useClickOutside(ref, onClose);
+
+  if (!isOpen) return null;
+
+  return (
+    <div ref={ref} className="dropdown-panel">
+      {children}
+    </div>
+  );
+}
+
+// Usage in a parent component
+function NavBar() {
+  const [open, setOpen] = React.useState(false);
+
+  return (
+    <nav>
+      <button onClick={() => setOpen(o => !o)}>Menú</button>
+      <Dropdown isOpen={open} onClose={() => setOpen(false)}>
+        <a href="/profile">Perfil</a>
+        <a href="/settings">Configuración</a>
+        <a href="/logout">Cerrar sesión</a>
+      </Dropdown>
+    </nav>
+  );
+}
+```
+
+## Notas
+
+- El hook escucha `mousedown`, no `click`. Esto se dispara antes del evento click, lo que evita que el manejador `click` del botón trigger reabra un elemento recién cerrado.
+- `callback` y `ref` se listan como dependencias del efecto. Si `callback` no está memoizada con `useCallback`, el listener se eliminará y volverá a añadirse en cada render. Envolver la callback en `useCallback` en el sitio de llamada cuando esto importe.
+- El listener se adjunta a `document`, por lo que captura eventos que se propagan hasta arriba. Los elementos que detienen la propagación con `e.stopPropagation()` en un manejador `mousedown` impedirán que se ejecute la callback.
+- Los eventos táctiles no se gestionan explícitamente; `mousedown` se dispara en dispositivos táctiles a través del sistema de eventos sintéticos, por lo que el hook funciona en móvil sin modificaciones.

--- a/docs/es/hooks/useDevice.md
+++ b/docs/es/hooks/useDevice.md
@@ -1,0 +1,64 @@
+# useDevice
+
+> [English](../../../docs/hooks/useDevice.md) | [Versione italiana](../../it/hooks/useDevice.md)
+
+## Descripción general
+
+`useDevice` analiza la cadena User-Agent actual mediante `ua-parser-js` y devuelve un objeto estable que describe el tipo de dispositivo, SO, navegador y flags booleanos de conveniencia. El resultado se calcula una vez y se almacena en caché a nivel de módulo, por lo que las llamadas posteriores (incluso entre diferentes componentes) comparten el mismo objeto sin volver a analizar.
+
+## Importación
+
+```js
+import { useDevice } from 'thecore-auth';
+```
+
+## Parámetros
+
+Este hook no acepta parámetros.
+
+## Valor de retorno
+
+| Clave | Tipo | Descripción |
+|-------|------|-------------|
+| `type` | `string` | Tipo de dispositivo: `"mobile"`, `"tablet"` o `"desktop"`. |
+| `os` | `string | undefined` | Nombre del sistema operativo (p. ej. `"iOS"`, `"Android"`, `"Windows"`). |
+| `browser` | `string | undefined` | Nombre del navegador (p. ej. `"Chrome"`, `"Safari"`, `"Firefox"`). |
+| `vendor` | `string | null` | Fabricante del dispositivo (p. ej. `"Apple"`, `"Samsung"`), o `null` si se desconoce. |
+| `model` | `string | null` | Modelo del dispositivo (p. ej. `"iPhone"`, `"iPad"`), o `null` si se desconoce. |
+| `isMobile` | `boolean` | `true` para teléfonos. |
+| `isTablet` | `boolean` | `true` para tablets, incluyendo iPads enmascarados como escritorio por Safari. |
+| `isDesktop` | `boolean` | `true` cuando no es ni móvil ni tablet. |
+| `isIPhone` | `boolean` | `true` cuando el modelo del dispositivo es `"iPhone"`. |
+| `isIPad` | `boolean` | `true` para iPads, incluyendo aquellos en los que Safari reporta `MacIntel`. |
+| `isAndroid` | `boolean` | `true` cuando el SO es `"Android"`. |
+
+## Uso
+
+```jsx
+import { useDevice } from 'thecore-auth';
+
+function AdaptiveLayout({ children }) {
+  const { isMobile, isTablet, isDesktop, os } = useDevice();
+
+  return (
+    <div
+      className={
+        isMobile  ? 'layout-mobile'  :
+        isTablet  ? 'layout-tablet'  :
+                    'layout-desktop'
+      }
+    >
+      {isDesktop && <Sidebar />}
+      <main>{children}</main>
+      {isMobile && os === 'iOS' && <IOSInstallBanner />}
+    </div>
+  );
+}
+```
+
+## Notas
+
+- El UA se analiza como máximo una vez por carga de página. El resultado se almacena en una variable a nivel de módulo (`cachedDevice`), por lo que llamar a `useDevice` en múltiples componentes es gratuito después de la primera llamada.
+- La detección de iPad incluye un fallback para Safari ≥ 13 en iPadOS, que reporta `MacIntel` como plataforma. El hook comprueba `navigator.platform === "MacIntel" && "ontouchend" in document` para identificar estos dispositivos.
+- Dado que el resultado está en caché, no cambia de forma reactiva. Si el hook se usa en un contexto de renderizado del lado del servidor, `navigator` / `document` no estarán disponibles y el hook lanzará una excepción.
+- `useMemo` con un array de dependencias vacío se usa para garantizar la estabilidad referencial; el objeto devuelto es siempre la misma referencia en caché.

--- a/docs/es/hooks/useForm.md
+++ b/docs/es/hooks/useForm.md
@@ -1,0 +1,89 @@
+# useForm
+
+> [English](../../../docs/hooks/useForm.md) | [Versione italiana](../../it/hooks/useForm.md)
+
+## Descripción general
+
+`useForm` gestiona el estado de un formulario que puede contener tanto valores de campos primitivos como subidas de archivos. Maneja los cambios de campos, la adición, sustitución y eliminación de archivos, y genera automáticamente URLs de vista previa de objetos para archivos de imagen.
+
+## Importación
+
+```js
+import { useForm } from 'thecore-auth';
+```
+
+## Parámetros
+
+| Nombre | Tipo | Por defecto | Descripción |
+|--------|------|-------------|-------------|
+| `initialValues` | `object` | `{}` | Valores iniciales para todos los campos no-archivo, con clave por nombre de campo. |
+
+## Valor de retorno
+
+| Clave | Tipo | Descripción |
+|-------|------|-------------|
+| `values` | `object` | Valores actuales de los campos no-archivo. |
+| `handleChange` | `(field: string, value: any) => void` | Actualiza el valor de un único campo. |
+| `files` | `object` | Mapa nombre de campo → `File[]` para los archivos subidos. |
+| `previews` | `object` | Mapa nombre de campo → `string[]` de URLs de objeto para previsualizar imágenes. |
+| `addFiles` | `(field: string, fileList: FileList \| File[]) => void` | Agrega nuevos archivos a una lista existente sin reemplazar los anteriores. |
+| `replaceFiles` | `(field: string, fileList: FileList \| File[]) => void` | Reemplaza completamente la lista de archivos de un campo. |
+| `removeFile` | `(field: string, index: number) => void` | Elimina un único archivo y su vista previa por índice. |
+| `setValues` | `React.Dispatch` | Setter de estado directo para `values` — usar para actualizaciones masivas. |
+| `resetForm` | `() => void` | Restablece `values` a `initialValues` y limpia todos los archivos y vistas previas. |
+
+## Uso
+
+```jsx
+import { useForm } from 'thecore-auth';
+
+function ProfileForm({ onSubmit }) {
+  const { values, handleChange, files, previews, addFiles, removeFile, resetForm } = useForm({
+    username: '',
+    bio: '',
+  });
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    const formData = new FormData();
+    formData.append('username', values.username);
+    formData.append('bio', values.bio);
+    (files.avatar || []).forEach(f => formData.append('avatar', f));
+    onSubmit(formData);
+  };
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <input
+        value={values.username}
+        onChange={e => handleChange('username', e.target.value)}
+        placeholder="Nombre de usuario"
+      />
+      <textarea
+        value={values.bio}
+        onChange={e => handleChange('bio', e.target.value)}
+        placeholder="Biografía"
+      />
+      <input type="file" accept="image/*"
+        onChange={e => addFiles('avatar', e.target.files)} />
+
+      {(previews.avatar || []).map((url, i) => (
+        <div key={i}>
+          <img src={url} alt="vista previa" width={80} />
+          <button type="button" onClick={() => removeFile('avatar', i)}>Eliminar</button>
+        </div>
+      ))}
+
+      <button type="submit">Guardar</button>
+      <button type="button" onClick={resetForm}>Restablecer</button>
+    </form>
+  );
+}
+```
+
+## Notas
+
+- Las URLs de objeto creadas por `addFiles` y `replaceFiles` **no** se revocan automáticamente. Llamar a `URL.revokeObjectURL(url)` cuando la vista previa ya no sea necesaria para evitar fugas de memoria, especialmente cuando los usuarios suben muchos archivos de gran tamaño.
+- `handleChange` establece un único campo; para actualizaciones masivas de valores usar el dispatcher `setValues` devuelto directamente.
+- `files` y `values` se rastrean en objetos de estado separados, por lo que actualizar los archivos no provoca un re-render de los componentes que solo consumen `values`, y viceversa.
+- `resetForm` restaura `values` a la instantánea de `initialValues` capturada en el momento de la inicialización del hook — las mutaciones al objeto `initialValues` después del montaje no se reflejan.

--- a/docs/es/hooks/useIndexedDB.md
+++ b/docs/es/hooks/useIndexedDB.md
@@ -1,0 +1,81 @@
+# useIndexedDB
+
+> [English](../../../docs/hooks/useIndexedDB.md) | [Versione italiana](../../it/hooks/useIndexedDB.md)
+
+## Descripción general
+
+`useIndexedDB` abre una base de datos IndexedDB y expone una interfaz CRUD basada en Promise para un único almacén de objetos. La conexión a la base de datos se abre al montarse y se cierra al desmontarse. Un flag `isReady` señala cuándo la base de datos está abierta y las operaciones pueden realizarse de forma segura.
+
+## Importación
+
+```js
+import { useIndexedDB } from 'thecore-auth';
+```
+
+## Parámetros
+
+| Nombre | Tipo | Por defecto | Descripción |
+|--------|------|-------------|-------------|
+| `dbName` | `string` | — | Nombre de la base de datos IndexedDB a abrir o crear. |
+| `storeName` | `string` | — | Nombre del almacén de objetos a usar dentro de la base de datos. Se crea automáticamente en la primera apertura. |
+| `version` | `number` | `1` | Versión del esquema de la base de datos. Incrementar para desencadenar una migración `onupgradeneeded`. |
+
+## Valor de retorno
+
+| Clave | Tipo | Descripción |
+|-------|------|-------------|
+| `isReady` | `boolean` | `true` una vez que la conexión a la base de datos está abierta y las operaciones pueden ejecutarse. |
+| `get` | `(key: any) => Promise<any>` | Recupera el registro que coincide con la clave primaria. Resuelve `undefined` si no se encuentra. |
+| `getAll` | `() => Promise<any[]>` | Recupera todos los registros del almacén. |
+| `set` | `(data: object) => Promise<IDBValidKey>` | Inserta o actualiza un registro. El objeto `data` debe incluir el campo `id` (keyPath). |
+| `setWithAutoId` | `(data: object) => Promise<IDBValidKey>` | Igual que `set`, pero genera automáticamente un `id` numérico único si `data.id` está ausente. |
+| `remove` | `(id: any) => Promise<true>` | Elimina el registro con la clave primaria especificada. |
+| `clear` | `() => Promise<true>` | Elimina todos los registros del almacén. |
+
+## Uso
+
+```jsx
+import { useIndexedDB } from 'thecore-auth';
+
+function NoteList() {
+  const { isReady, getAll, setWithAutoId, remove } = useIndexedDB('notesDB', 'notes');
+  const [notes, setNotes] = React.useState([]);
+
+  // Load all notes once the DB is open
+  React.useEffect(() => {
+    if (!isReady) return;
+    getAll().then(setNotes);
+  }, [isReady, getAll]);
+
+  const addNote = async () => {
+    await setWithAutoId({ text: 'Nueva nota', createdAt: Date.now() });
+    setNotes(await getAll());
+  };
+
+  const deleteNote = async (id) => {
+    await remove(id);
+    setNotes(await getAll());
+  };
+
+  return (
+    <div>
+      <button onClick={addNote}>Agregar nota</button>
+      <ul>
+        {notes.map(n => (
+          <li key={n.id}>
+            {n.text} <button onClick={() => deleteNote(n.id)}>Eliminar</button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+```
+
+## Notas
+
+- El almacén de objetos se crea con `keyPath: "id"` en la primera apertura. Los registros deben incluir un campo `id` cuando se usa `set` directamente.
+- `setWithAutoId` genera IDs usando `Date.now()` e incrementa hasta encontrar un valor sin colisiones — adecuado para escrituras de bajo volumen; no recomendado para escenarios de alta concurrencia.
+- Todas las operaciones rechazan con una cadena de error (`"DB non pronto"`) si se llaman antes de que `isReady` sea `true`.
+- Solo se gestiona un almacén de objetos por instancia del hook. Para múltiples almacenes, instanciar el hook varias veces con el mismo `dbName` y diferentes valores `storeName`.
+- La conexión a la base de datos se cierra automáticamente cuando el componente se desmonta.

--- a/docs/es/hooks/useOrientation.md
+++ b/docs/es/hooks/useOrientation.md
@@ -1,0 +1,54 @@
+# useOrientation
+
+> [English](../../../docs/hooks/useOrientation.md) | [Versione italiana](../../it/hooks/useOrientation.md)
+
+## Descripción general
+
+`useOrientation` devuelve la orientación actual de la pantalla como una cadena de texto y se actualiza reactivamente cada vez que se redimensiona la ventana. La orientación se determina comparando `window.innerWidth` y `window.innerHeight`.
+
+## Importación
+
+```js
+import { useOrientation } from 'thecore-auth';
+```
+
+## Parámetros
+
+Este hook no acepta parámetros.
+
+## Valor de retorno
+
+| Tipo | Valores | Descripción |
+|------|---------|-------------|
+| `string` | `"landscape"` | `"portrait"` | Orientación actual. `"landscape"` cuando el ancho > alto, `"portrait"` en caso contrario. |
+
+## Uso
+
+```jsx
+import { useOrientation } from 'thecore-auth';
+
+function OrientationBanner() {
+  const orientation = useOrientation();
+
+  if (orientation === 'portrait') {
+    return (
+      <div className="rotate-prompt">
+        Por favor, gira tu dispositivo al modo horizontal.
+      </div>
+    );
+  }
+
+  return (
+    <main>
+      <p>Contenido mostrado en orientación horizontal.</p>
+    </main>
+  );
+}
+```
+
+## Notas
+
+- La orientación se deriva de las dimensiones de la ventana, no de la API `screen.orientation`, por lo que reacciona a cualquier redimensionamiento — incluyendo el redimensionamiento de la ventana del navegador en escritorio.
+- El valor inicial se calcula de forma síncrona desde `window.innerWidth` y `window.innerHeight` en el momento en que se llama al hook por primera vez.
+- El listener de eventos se adjunta a `resize` y se limpia al desmontar, por lo que no hay fugas de memoria.
+- En iOS Safari, los cambios de orientación pueden disparar un evento `resize` con un ligero retraso. Considerar el debouncing si la precisión temporal es importante.

--- a/docs/es/hooks/useSafeArea.md
+++ b/docs/es/hooks/useSafeArea.md
@@ -1,0 +1,57 @@
+# useSafeArea
+
+> [English](../../../docs/hooks/useSafeArea.md) | [Versione italiana](../../it/hooks/useSafeArea.md)
+
+## Descripción general
+
+`useSafeArea` gestiona la clase CSS `with-safe-area` en `document.body`. Cuando la ruta actual **no** está en la lista de exclusión, la clase se agrega para que se respeten los safe-area insets (p. ej. notch / barra de inicio del iPhone). La clase se elimina en las rutas excluidas (típicamente la página de inicio de sesión) donde se desean layouts a pantalla completa.
+
+## Importación
+
+```js
+import { useSafeArea } from 'thecore-auth';
+```
+
+## Parámetros
+
+| Nombre | Tipo | Por defecto | Descripción |
+|--------|------|-------------|-------------|
+| `excludedPaths` | `string[]` | `["/"]` | Array de pathnames exactos donde la clase safe-area **no** debe aplicarse. |
+
+## Valor de retorno
+
+Este hook no devuelve nada (`void`). Funciona únicamente como efecto secundario.
+
+## Uso
+
+```jsx
+import { useSafeArea } from 'thecore-auth';
+
+function App() {
+  // Apply safe-area everywhere except the login and splash pages
+  useSafeArea(['/', '/splash']);
+
+  return (
+    <Routes>
+      <Route path="/"       element={<Login />} />
+      <Route path="/splash" element={<Splash />} />
+      <Route path="/app"    element={<Dashboard />} />
+    </Routes>
+  );
+}
+```
+
+```css
+/* In your global CSS, define what with-safe-area means */
+.with-safe-area {
+  padding-bottom: env(safe-area-inset-bottom);
+  padding-top:    env(safe-area-inset-top);
+}
+```
+
+## Notas
+
+- Debe llamarse dentro de un componente descendiente de `<BrowserRouter>` (o equivalente), ya que depende de `useLocation`.
+- La coincidencia de rutas es una comparación exacta de cadenas (`includes`). Los segmentos dinámicos (p. ej. `/user/123`) **no** se comparan con un patrón como `/user/:id` — listar los paths literales que deben excluirse.
+- La clase se elimina en el cleanup del efecto, por lo que navegar fuera de una ruta siempre comienza con un estado limpio antes de que se ejecute el nuevo efecto.
+- Si la manipulación de la clase de `document.body` entra en conflicto con otras librerías, considerar el uso de una variable CSS o un enfoque con atributos data y adaptar el hook en consecuencia.

--- a/docs/es/hooks/useStorage.md
+++ b/docs/es/hooks/useStorage.md
@@ -1,0 +1,67 @@
+# useStorage
+
+> [English](../../../docs/hooks/useStorage.md) | [Versione italiana](../../it/hooks/useStorage.md)
+
+## Descripción general
+
+`useStorage` es un hook compatible con `useState` que mantiene un valor sincronizado con `localStorage`. Al montarse lee el valor almacenado (o escribe el valor inicial si la clave está ausente). El setter devuelto persiste cada actualización automáticamente.
+
+## Importación
+
+```js
+import { useStorage } from 'thecore-auth';
+```
+
+## Parámetros
+
+| Nombre | Tipo | Por defecto | Descripción |
+|--------|------|-------------|-------------|
+| `initialValue` | `any` | — | Valor escrito en `localStorage` cuando la clave no existe todavía. |
+| `itemKey` | `string` | — | Clave de `localStorage` bajo la cual se almacena el valor (serializado en JSON). |
+
+## Valor de retorno
+
+Devuelve una tupla de tres elementos:
+
+| Índice | Valor | Tipo | Descripción |
+|--------|-------|------|-------------|
+| `0` | `state` | `any` | Valor actual, inicializado desde `localStorage`. |
+| `1` | `changeState` | `(value | (prev) => value) => void` | Setter que actualiza tanto el estado de React como `localStorage`. Acepta un valor o una función actualizadora. |
+| `2` | `remove` | `(clearAll?: boolean) => void` | Elimina la clave de `localStorage` y restablece el estado a `initialValue`. Pasar `true` para llamar a `localStorage.clear()`. |
+
+## Uso
+
+```jsx
+import { useStorage } from 'thecore-auth';
+
+function ThemeToggle() {
+  const [theme, setTheme, removeTheme] = useStorage('light', 'app-theme');
+
+  return (
+    <div>
+      <p>Tema actual: {theme}</p>
+
+      <button onClick={() => setTheme(t => t === 'light' ? 'dark' : 'light')}>
+        Cambiar tema
+      </button>
+
+      {/* Removes only the 'app-theme' key */}
+      <button onClick={() => removeTheme()}>
+        Restablecer tema
+      </button>
+
+      {/* Clears ALL localStorage — use with caution */}
+      <button onClick={() => removeTheme(true)}>
+        Limpiar todo el almacenamiento
+      </button>
+    </div>
+  );
+}
+```
+
+## Notas
+
+- Los valores se serializan en JSON antes de almacenarse y se analizan al leerlos. Los valores no serializables (p. ej. funciones, `undefined`) no se conservarán correctamente.
+- Si `localStorage` no está disponible (p. ej. navegación privada con almacenamiento bloqueado), el hook registra el error y recurre a `initialValue` sin lanzar excepciones.
+- `changeState` acepta una función actualizadora `(prev) => newValue`, haciéndolo compatible con patrones que dependen del estado anterior.
+- `remove(true)` llama a `localStorage.clear()`, que elimina **todas** las claves — no solo las gestionadas por este hook. Usar con precaución.

--- a/docs/es/hooks/useToast.md
+++ b/docs/es/hooks/useToast.md
@@ -1,0 +1,76 @@
+# useToast
+
+> [English](../../../docs/hooks/useToast.md) | [Versione italiana](../../it/hooks/useToast.md)
+
+## Descripción general
+
+`useToast` proporciona una interfaz tipada alrededor de la librería de notificaciones [Sileo](https://github.com/sileo-js/sileo). Expone una función por cada variante de toast — `success`, `error`, `info`, `warning` y `promise` — para que los componentes puedan mostrar mensajes de feedback sin importar Sileo directamente.
+
+## Importación
+
+```js
+import { useToast } from 'thecore-auth';
+```
+
+## Parámetros
+
+Este hook no acepta parámetros.
+
+## Valor de retorno
+
+| Clave | Tipo | Descripción |
+|-------|------|-------------|
+| `success` | `(title: string, description?: string) => void` | Muestra un toast verde de éxito. |
+| `error` | `(title: string, description?: string) => void` | Muestra un toast rojo de error. |
+| `info` | `(title: string, description?: string) => void` | Muestra un toast azul informativo. |
+| `warning` | `(title: string, description?: string) => void` | Muestra un toast naranja de advertencia. |
+| `promise` | `(promise: Promise, messages: SileoPromiseMessages) => void` | Muestra un toast de carga que transiciona a éxito o error según el resultado de la promise. |
+
+## Uso
+
+```jsx
+import { useToast } from 'thecore-auth';
+
+function SaveButton({ onSave }) {
+  const toast = useToast();
+
+  const handleClick = async () => {
+    try {
+      await toast.promise(
+        onSave(),
+        {
+          loading: 'Guardando...',
+          success: { title: 'Guardado', description: 'Los cambios se guardaron correctamente.' },
+          error:   { title: 'Error',    description: 'No se pudo guardar. Inténtalo de nuevo.' },
+        }
+      );
+    } catch {
+      toast.error('Error inesperado', 'Por favor contacta con soporte.');
+    }
+  };
+
+  return <button onClick={handleClick}>Guardar</button>;
+}
+
+// Simple feedback example
+function DeleteButton({ onDelete }) {
+  const { success, error } = useToast();
+
+  const handleDelete = async () => {
+    try {
+      await onDelete();
+      success('Eliminado', 'El elemento se eliminó correctamente.');
+    } catch {
+      error('Error al eliminar', 'El elemento no pudo eliminarse.');
+    }
+  };
+
+  return <button onClick={handleDelete}>Eliminar</button>;
+}
+```
+
+## Notas
+
+- Sileo debe estar configurado en la raíz de la aplicación (p. ej. `<SileoProvider />`) para que los toasts se rendericen. `useToast` solo envuelve la API imperativa — no monta el contenedor.
+- El método `promise` refleja la firma de `sileo.promise`. Consultar la documentación de Sileo para la forma exacta del argumento `messages`.
+- Todas las funciones devueltas se recrean en cada render (sin `useCallback`). Si se pasan como props o se usan en dependencias de `useEffect`, memoizar en el sitio de llamada si es necesario.

--- a/docs/es/hooks/useViewportHeight.md
+++ b/docs/es/hooks/useViewportHeight.md
@@ -1,0 +1,72 @@
+# useViewportHeight
+
+> [English](../../../docs/hooks/useViewportHeight.md) | [Versione italiana](../../it/hooks/useViewportHeight.md)
+
+## Descripción general
+
+`useViewportHeight` resuelve el "problema del 100vh" en los navegadores móviles donde la barra de direcciones se encoge y crece, causando saltos en el layout. Establece la propiedad CSS personalizada `--vh` (igual al 1% de la altura real del viewport visible) y opcionalmente devuelve los valores en píxeles para su uso en JavaScript.
+
+## Importación
+
+```js
+import { useViewportHeight } from 'thecore-auth';
+```
+
+## Parámetros
+
+| Nombre | Tipo | Por defecto | Descripción |
+|--------|------|-------------|-------------|
+| `options` | `{ getValues?: boolean }` | `{ getValues: false }` | Cuando `getValues` es `true`, el hook también rastrea la altura del viewport en el estado de React y devuelve valores numéricos. |
+
+## Valor de retorno
+
+Cuando `options.getValues` es `false` (por defecto):
+
+| Tipo | Descripción |
+|------|-------------|
+| `null` | No devuelve nada. Solo se actualiza la propiedad CSS `--vh`. |
+
+Cuando `options.getValues` es `true`:
+
+| Clave | Tipo | Descripción |
+|-------|------|-------------|
+| `height` | `number` | Altura actual del viewport visible en píxeles. |
+| `vh` | `number` | `height * 0.01` — equivalente a `1vh` en píxeles. |
+
+## Uso
+
+```jsx
+import { useViewportHeight } from 'thecore-auth';
+
+// CSS-only usage — no JS values needed
+function AppLayout({ children }) {
+  useViewportHeight(); // sets --vh, returns null
+
+  return (
+    // Use calc(var(--vh) * 100) instead of 100vh in CSS
+    <div style={{ height: 'calc(var(--vh, 1vh) * 100)' }}>
+      {children}
+    </div>
+  );
+}
+
+// JS values usage — e.g. for canvas sizing
+function FullscreenCanvas() {
+  const { height, vh } = useViewportHeight({ getValues: true });
+
+  return (
+    <canvas
+      width={window.innerWidth}
+      height={height}
+      style={{ display: 'block' }}
+    />
+  );
+}
+```
+
+## Notas
+
+- `--vh` se establece en `document.documentElement`, por lo que está disponible globalmente en tu CSS como `var(--vh)`. Usar `calc(var(--vh) * 100)` donde normalmente se escribiría `100vh`.
+- El hook usa `window.visualViewport.height` cuando está disponible (navegadores modernos), con fallback a `window.innerHeight`. `visualViewport` excluye correctamente el teclado en pantalla en iOS y Android.
+- Los listeners de eventos para `resize` y `orientationchange` se registran al montarse y se eliminan al desmontarse.
+- Cuando `getValues` es `false`, no se actualiza ningún estado de React en el resize, manteniendo los re-renders a cero. Solo cambiar a `{ getValues: true }` cuando genuinamente se necesiten valores numéricos en JavaScript.

--- a/docs/hooks/UsePageTitle.md
+++ b/docs/hooks/UsePageTitle.md
@@ -1,0 +1,60 @@
+# UsePageTitle
+
+> [Versione italiana](../../it/hooks/UsePageTitle.md) | [Versión española](../../es/hooks/UsePageTitle.md)
+
+## Overview
+
+`UsePageTitle` automatically updates `document.title` based on the current route. It matches the active path against a list of route definitions — including dynamic segments like `/dashboard/:id` — and sets the tab title accordingly.
+
+## Import
+
+```js
+import { UsePageTitle } from 'thecore-auth';
+```
+
+## Parameters
+
+| Name | Type | Default | Description |
+|------|------|---------|-------------|
+| `routes` | `Array<{ path: string, title: string }>` | `[]` | Route definitions mapping a path pattern to a page title. Supports React Router dynamic segments. |
+| `defaultTitle` | `string` | `"SPOT"` | Title used when no route matches the current path. |
+
+## Return value
+
+This hook returns nothing (`void`). It operates as a side effect only.
+
+## Usage
+
+```jsx
+import { UsePageTitle } from 'thecore-auth';
+
+const PAGE_TITLES = [
+  { path: '/',               title: 'Login' },
+  { path: '/dashboard',      title: 'Dashboard' },
+  { path: '/dashboard/:id',  title: 'Task Detail' },
+  { path: '/profile',        title: 'My Profile' },
+  { path: '/settings',       title: 'Settings' },
+];
+
+function AppRoutes() {
+  // Sets document.title on every navigation, falls back to "SPOT"
+  UsePageTitle(PAGE_TITLES, 'SPOT');
+
+  return (
+    <Routes>
+      <Route path="/" element={<Login />} />
+      <Route path="/dashboard" element={<Dashboard />} />
+      <Route path="/dashboard/:id" element={<TaskDetail />} />
+      <Route path="/profile" element={<Profile />} />
+      <Route path="/settings" element={<Settings />} />
+    </Routes>
+  );
+}
+```
+
+## Notes
+
+- Must be called inside a component that is a descendant of `<BrowserRouter>` (or equivalent), because it relies on `useLocation`.
+- Uses `matchPath` with `end: true`, so `/dashboard` does not match `/dashboard/123`. Add explicit dynamic-segment entries when needed.
+- The update runs inside `useLayoutEffect` to avoid a flash of the previous title on navigation.
+- The hook is exported with a capital `U` (`UsePageTitle`) — this is intentional and matches the source naming convention.

--- a/docs/hooks/useAuthStorage.md
+++ b/docs/hooks/useAuthStorage.md
@@ -1,0 +1,63 @@
+# useAuthStorage
+
+> [Versione italiana](../../it/hooks/useAuthStorage.md) | [Versión española](../../es/hooks/useAuthStorage.md)
+
+## Overview
+
+`useAuthStorage` manages the two authentication values stored in `localStorage` — the access token and the user object — through a unified interface. It is built on top of [`useStorage`](./useStorage.md) and is used internally by `AuthProvider`.
+
+## Import
+
+```js
+import { useAuthStorage } from 'thecore-auth';
+```
+
+## Parameters
+
+This hook accepts no parameters.
+
+## Return value
+
+| Key | Type | Description |
+|-----|------|-------------|
+| `token` | `string \| null` | JWT access token read from `localStorage` key `"accessToken"`. |
+| `user` | `object \| null` | User object read from `localStorage` key `"user"`. |
+| `setToken` | `(value) => void` | Persists a new access token to state and `localStorage`. |
+| `setUser` | `(value) => void` | Persists a new user object to state and `localStorage`. |
+| `storageLogout` | `() => void` | Removes both `"accessToken"` and `"user"` from `localStorage` and resets state to `null`. |
+
+## Usage
+
+```jsx
+import { useAuthStorage } from 'thecore-auth';
+
+function SessionPanel() {
+  const { token, user, setToken, setUser, storageLogout } = useAuthStorage();
+
+  const handleLogin = (authResponse) => {
+    setToken(authResponse.accessToken);
+    setUser(authResponse.user);
+  };
+
+  const handleLogout = () => {
+    storageLogout(); // clears both token and user from localStorage
+  };
+
+  if (!token) {
+    return <button onClick={() => handleLogin({ accessToken: 'abc', user: { name: 'Alice' } })}>Log in</button>;
+  }
+
+  return (
+    <div>
+      <p>Logged in as {user?.name}</p>
+      <button onClick={handleLogout}>Log out</button>
+    </div>
+  );
+}
+```
+
+## Notes
+
+- `token` and `user` are initialised from `localStorage` on first render, so the session survives page refreshes.
+- `storageLogout` calls `removeToken()` and `removeUser()` individually; it does **not** call `localStorage.clear()`, so unrelated keys are preserved.
+- Prefer consuming auth state through `useAuth` (the `AuthContext` hook) rather than calling `useAuthStorage` directly — `AuthProvider` already manages these values for you.

--- a/docs/hooks/useCalendar.md
+++ b/docs/hooks/useCalendar.md
@@ -1,0 +1,78 @@
+# useCalendar
+
+> [Versione italiana](../../it/hooks/useCalendar.md) | [Versión española](../../es/hooks/useCalendar.md)
+
+## Overview
+
+`useCalendar` provides holiday data and calendar utility functions for a given year and country. It uses the [`date-holidays`](https://github.com/commenthol/date-holidays) library to load the holiday list, exposes a fast lookup Map, and offers helpers to generate weeks, months, and arbitrary date ranges.
+
+## Import
+
+```js
+import { useCalendar } from 'thecore-auth';
+```
+
+## Parameters
+
+| Name | Type | Default | Description |
+|------|------|---------|-------------|
+| `year` | `number` | current year | The year for which holidays are loaded. |
+| `country` | `string` | `"IT"` | ISO 3166-1 alpha-2 country code used by `date-holidays`. |
+
+## Return value
+
+| Key | Type | Description |
+|-----|------|-------------|
+| `holidays` | `object[]` | Raw holiday objects returned by `date-holidays` for the configured year. |
+| `holidayMap` | `Map<string, object>` | Map keyed by `"YYYY-MM-DD"` for O(1) holiday lookup. |
+| `isTodayHoliday` | `() => boolean` | Returns `true` if today is a holiday. |
+| `isHoliday` | `(date: Date \| string) => boolean` | Returns `true` if the given date is a holiday. Accepts a `Date` object or a string in `"YYYY-MM-DD"` or `"DD/MM/YYYY"` format. |
+| `getWeekDays` | `(date: Date \| string) => Date[]` | Returns an array of 7 `Date` objects for the Monday-to-Sunday week containing `date`. |
+| `getWeeksInMonth` | `(month: number, year?: number) => Date[][]` | Returns an array of weeks, each a 7-element `Date[]`, covering the given month (0-indexed). |
+| `getDaysInMonth` | `(month: number, year?: number) => Date[]` | Returns all days in the given month as `Date[]`. |
+| `getDaysInMonths` | `(startMonth: number, startYear?: number, numMonths?: number) => Date[]` | Returns all days across `numMonths` consecutive months starting from `startMonth`. |
+| `getDaysInYear` | `(year: number) => Date[]` | Returns all 365/366 days in the given year as `Date[]`. |
+
+## Usage
+
+```jsx
+import { useCalendar } from 'thecore-auth';
+
+function MonthView({ month, year }) {
+  const { getWeeksInMonth, isHoliday, isTodayHoliday } = useCalendar(year, 'IT');
+
+  const weeks = getWeeksInMonth(month, year);
+  const today = new Date().toDateString();
+
+  return (
+    <div>
+      {isTodayHoliday() && <p>Today is a public holiday!</p>}
+      {weeks.map((week, wi) => (
+        <div key={wi} style={{ display: 'flex' }}>
+          {week.map((day, di) => (
+            <div
+              key={di}
+              style={{
+                background: isHoliday(day) ? '#fdd' : day.toDateString() === today ? '#dfd' : '#fff',
+                border: '1px solid #ccc',
+                padding: '4px 8px',
+                minWidth: 36,
+                textAlign: 'center',
+              }}
+            >
+              {day.getDate()}
+            </div>
+          ))}
+        </div>
+      ))}
+    </div>
+  );
+}
+```
+
+## Notes
+
+- Holidays are loaded asynchronously inside a `useEffect`. The `holidays` array and `holidayMap` are empty on the first render and populated once the effect runs. Guard against this if you render immediately on mount.
+- `getDaysInMonths` handles year roll-overs: starting from month `10` with `numMonths = 6` correctly spans into the following year.
+- `getWeeksInMonth` may include days from the preceding or following month to complete the first and last weeks of the grid. Check `day.getMonth() !== month` if you need to hide out-of-month days.
+- Date keys in `holidayMap` are derived from local time (not UTC), so they match correctly regardless of the user's timezone offset.

--- a/docs/hooks/useClickOutside.md
+++ b/docs/hooks/useClickOutside.md
@@ -1,0 +1,69 @@
+# useClickOutside
+
+> [Versione italiana](../../it/hooks/useClickOutside.md) | [Versión española](../../es/hooks/useClickOutside.md)
+
+## Overview
+
+`useClickOutside` calls a callback whenever the user clicks (or taps) outside a referenced DOM element. It is the standard building block for closing dropdowns, modals, popovers, and context menus on an outside click.
+
+## Import
+
+```js
+import { useClickOutside } from 'thecore-auth';
+```
+
+## Parameters
+
+| Name | Type | Default | Description |
+|------|------|---------|-------------|
+| `ref` | `React.RefObject<HTMLElement>` | — | Ref attached to the element that defines the "inside" area. |
+| `callback` | `() => void` | — | Function called when a `mousedown` event fires outside the ref element. |
+
+## Return value
+
+This hook returns nothing (`void`). It operates as a side effect only.
+
+## Usage
+
+```jsx
+import { useRef } from 'react';
+import { useClickOutside } from 'thecore-auth';
+
+function Dropdown({ isOpen, onClose, children }) {
+  const ref = useRef(null);
+
+  // Close the dropdown whenever the user clicks outside
+  useClickOutside(ref, onClose);
+
+  if (!isOpen) return null;
+
+  return (
+    <div ref={ref} className="dropdown-panel">
+      {children}
+    </div>
+  );
+}
+
+// Usage in a parent component
+function NavBar() {
+  const [open, setOpen] = React.useState(false);
+
+  return (
+    <nav>
+      <button onClick={() => setOpen(o => !o)}>Menu</button>
+      <Dropdown isOpen={open} onClose={() => setOpen(false)}>
+        <a href="/profile">Profile</a>
+        <a href="/settings">Settings</a>
+        <a href="/logout">Logout</a>
+      </Dropdown>
+    </nav>
+  );
+}
+```
+
+## Notes
+
+- The hook listens on `mousedown`, not `click`. This fires before the click event, which prevents the trigger button's `click` handler from reopening a just-closed element.
+- `callback` and `ref` are listed as effect dependencies. If `callback` is not memoised with `useCallback`, the listener will be removed and re-added on every render. Wrap the callback in `useCallback` at the call site when this matters.
+- The listener is attached to `document`, so it captures events that bubble all the way up. Elements that stop propagation with `e.stopPropagation()` in a `mousedown` handler will prevent the callback from firing.
+- Touch events are not explicitly handled; `mousedown` fires on touch devices through the synthetic event system, so the hook works on mobile without modification.

--- a/docs/hooks/useDevice.md
+++ b/docs/hooks/useDevice.md
@@ -1,0 +1,64 @@
+# useDevice
+
+> [Versione italiana](../../it/hooks/useDevice.md) | [Versión española](../../es/hooks/useDevice.md)
+
+## Overview
+
+`useDevice` parses the current User-Agent string via `ua-parser-js` and returns a stable object describing the device type, OS, browser, and convenience boolean flags. The result is computed once and cached at module level, so subsequent calls (even across different components) share the same object without re-parsing.
+
+## Import
+
+```js
+import { useDevice } from 'thecore-auth';
+```
+
+## Parameters
+
+This hook accepts no parameters.
+
+## Return value
+
+| Key | Type | Description |
+|-----|------|-------------|
+| `type` | `string` | Device type: `"mobile"`, `"tablet"`, or `"desktop"`. |
+| `os` | `string \| undefined` | Operating system name (e.g. `"iOS"`, `"Android"`, `"Windows"`). |
+| `browser` | `string \| undefined` | Browser name (e.g. `"Chrome"`, `"Safari"`, `"Firefox"`). |
+| `vendor` | `string \| null` | Device manufacturer (e.g. `"Apple"`, `"Samsung"`), or `null` if unknown. |
+| `model` | `string \| null` | Device model (e.g. `"iPhone"`, `"iPad"`), or `null` if unknown. |
+| `isMobile` | `boolean` | `true` for phones. |
+| `isTablet` | `boolean` | `true` for tablets, including iPads masked as desktop by Safari. |
+| `isDesktop` | `boolean` | `true` when neither mobile nor tablet. |
+| `isIPhone` | `boolean` | `true` when the device model is `"iPhone"`. |
+| `isIPad` | `boolean` | `true` for iPads, including those where Safari reports `MacIntel`. |
+| `isAndroid` | `boolean` | `true` when the OS is `"Android"`. |
+
+## Usage
+
+```jsx
+import { useDevice } from 'thecore-auth';
+
+function AdaptiveLayout({ children }) {
+  const { isMobile, isTablet, isDesktop, os } = useDevice();
+
+  return (
+    <div
+      className={
+        isMobile  ? 'layout-mobile'  :
+        isTablet  ? 'layout-tablet'  :
+                    'layout-desktop'
+      }
+    >
+      {isDesktop && <Sidebar />}
+      <main>{children}</main>
+      {isMobile && os === 'iOS' && <IOSInstallBanner />}
+    </div>
+  );
+}
+```
+
+## Notes
+
+- The UA is parsed at most once per page load. The result is stored in a module-level variable (`cachedDevice`), so calling `useDevice` in multiple components is free after the first call.
+- iPad detection includes a fallback for Safari ≥ 13 on iPadOS, which reports `MacIntel` as the platform. The hook checks `navigator.platform === "MacIntel" && "ontouchend" in document` to identify these devices.
+- Because the result is cached, it does not change reactively. If the hook is used in a server-side rendering context, `navigator` / `document` will not be available and the hook will throw.
+- `useMemo` with an empty dependency array is used to guarantee referential stability; the returned object is always the same cached reference.

--- a/docs/hooks/useForm.md
+++ b/docs/hooks/useForm.md
@@ -1,0 +1,89 @@
+# useForm
+
+> [Versione italiana](../../it/hooks/useForm.md) | [Versión española](../../es/hooks/useForm.md)
+
+## Overview
+
+`useForm` manages the state of a form that can contain both primitive field values and file uploads. It handles field changes, file additions, replacements, and removals, and generates object-URL previews for image files automatically.
+
+## Import
+
+```js
+import { useForm } from 'thecore-auth';
+```
+
+## Parameters
+
+| Name | Type | Default | Description |
+|------|------|---------|-------------|
+| `initialValues` | `object` | `{}` | Initial values for all non-file fields, keyed by field name. |
+
+## Return value
+
+| Key | Type | Description |
+|-----|------|-------------|
+| `values` | `object` | Current non-file field values. |
+| `handleChange` | `(field: string, value: any) => void` | Updates a single field value. |
+| `files` | `object` | Map of field name → `File[]` for uploaded files. |
+| `previews` | `object` | Map of field name → `string[]` of object URLs for previewing images. |
+| `addFiles` | `(field: string, fileList: FileList \| File[]) => void` | Appends new files to an existing list without replacing previous ones. |
+| `replaceFiles` | `(field: string, fileList: FileList \| File[]) => void` | Replaces the entire file list for a field. |
+| `removeFile` | `(field: string, index: number) => void` | Removes a single file and its preview by index. |
+| `setValues` | `React.Dispatch` | Direct state setter for `values` — use for bulk updates. |
+| `resetForm` | `() => void` | Resets `values` to `initialValues` and clears all files and previews. |
+
+## Usage
+
+```jsx
+import { useForm } from 'thecore-auth';
+
+function ProfileForm({ onSubmit }) {
+  const { values, handleChange, files, previews, addFiles, removeFile, resetForm } = useForm({
+    username: '',
+    bio: '',
+  });
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    const formData = new FormData();
+    formData.append('username', values.username);
+    formData.append('bio', values.bio);
+    (files.avatar || []).forEach(f => formData.append('avatar', f));
+    onSubmit(formData);
+  };
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <input
+        value={values.username}
+        onChange={e => handleChange('username', e.target.value)}
+        placeholder="Username"
+      />
+      <textarea
+        value={values.bio}
+        onChange={e => handleChange('bio', e.target.value)}
+        placeholder="Bio"
+      />
+      <input type="file" accept="image/*"
+        onChange={e => addFiles('avatar', e.target.files)} />
+
+      {(previews.avatar || []).map((url, i) => (
+        <div key={i}>
+          <img src={url} alt="preview" width={80} />
+          <button type="button" onClick={() => removeFile('avatar', i)}>Remove</button>
+        </div>
+      ))}
+
+      <button type="submit">Save</button>
+      <button type="button" onClick={resetForm}>Reset</button>
+    </form>
+  );
+}
+```
+
+## Notes
+
+- Object URLs created by `addFiles` and `replaceFiles` are **not** automatically revoked. Call `URL.revokeObjectURL(url)` when the preview is no longer needed to avoid memory leaks, especially when users upload many large files.
+- `handleChange` sets a single field; for bulk value updates use the returned `setValues` dispatcher directly.
+- `files` and `values` are tracked in separate state objects, so updating files does not re-render components that only consume `values`, and vice versa (in practice React batches them, but the separation keeps each piece of state minimal).
+- `resetForm` restores `values` to the `initialValues` snapshot captured at hook initialisation time — mutations to the `initialValues` object after mount are not reflected.

--- a/docs/hooks/useIndexedDB.md
+++ b/docs/hooks/useIndexedDB.md
@@ -1,0 +1,81 @@
+# useIndexedDB
+
+> [Versione italiana](../../it/hooks/useIndexedDB.md) | [Versión española](../../es/hooks/useIndexedDB.md)
+
+## Overview
+
+`useIndexedDB` opens an IndexedDB database and exposes a Promise-based CRUD interface for a single object store. The database connection is opened on mount and closed on unmount. An `isReady` flag signals when the database is open and operations can be performed safely.
+
+## Import
+
+```js
+import { useIndexedDB } from 'thecore-auth';
+```
+
+## Parameters
+
+| Name | Type | Default | Description |
+|------|------|---------|-------------|
+| `dbName` | `string` | — | Name of the IndexedDB database to open or create. |
+| `storeName` | `string` | — | Name of the object store to use within the database. Created automatically on first open. |
+| `version` | `number` | `1` | Database schema version. Increment to trigger an `onupgradeneeded` migration. |
+
+## Return value
+
+| Key | Type | Description |
+|-----|------|-------------|
+| `isReady` | `boolean` | `true` once the database connection is open and operations can be executed. |
+| `get` | `(key: any) => Promise<any>` | Retrieves the record matching the primary key. Resolves `undefined` if not found. |
+| `getAll` | `() => Promise<any[]>` | Retrieves all records in the store. |
+| `set` | `(data: object) => Promise<IDBValidKey>` | Inserts or updates a record. The `data` object must include the `id` field (keyPath). |
+| `setWithAutoId` | `(data: object) => Promise<IDBValidKey>` | Same as `set`, but auto-generates a unique numeric `id` if `data.id` is absent. |
+| `remove` | `(id: any) => Promise<true>` | Deletes the record with the given primary key. |
+| `clear` | `() => Promise<true>` | Deletes all records in the store. |
+
+## Usage
+
+```jsx
+import { useIndexedDB } from 'thecore-auth';
+
+function NoteList() {
+  const { isReady, getAll, setWithAutoId, remove } = useIndexedDB('notesDB', 'notes');
+  const [notes, setNotes] = React.useState([]);
+
+  // Load all notes once the DB is open
+  React.useEffect(() => {
+    if (!isReady) return;
+    getAll().then(setNotes);
+  }, [isReady, getAll]);
+
+  const addNote = async () => {
+    await setWithAutoId({ text: 'New note', createdAt: Date.now() });
+    setNotes(await getAll());
+  };
+
+  const deleteNote = async (id) => {
+    await remove(id);
+    setNotes(await getAll());
+  };
+
+  return (
+    <div>
+      <button onClick={addNote}>Add note</button>
+      <ul>
+        {notes.map(n => (
+          <li key={n.id}>
+            {n.text} <button onClick={() => deleteNote(n.id)}>Delete</button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+```
+
+## Notes
+
+- The object store is created with `keyPath: "id"` on first open. Records must include an `id` field when using `set` directly.
+- `setWithAutoId` generates IDs using `Date.now()` and increments until a collision-free value is found — suitable for low-volume writes; not recommended for high-concurrency scenarios.
+- All operations reject with an error message string (`"DB non pronto"`) if called before `isReady` is `true`.
+- Only a single object store per hook instance is managed. For multiple stores, instantiate the hook multiple times with the same `dbName` and different `storeName` values.
+- The database connection is closed automatically when the component unmounts.

--- a/docs/hooks/useOrientation.md
+++ b/docs/hooks/useOrientation.md
@@ -1,0 +1,54 @@
+# useOrientation
+
+> [Versione italiana](../../it/hooks/useOrientation.md) | [Versión española](../../es/hooks/useOrientation.md)
+
+## Overview
+
+`useOrientation` returns the current screen orientation as a string and updates reactively whenever the window is resized. Orientation is determined by comparing `window.innerWidth` and `window.innerHeight`.
+
+## Import
+
+```js
+import { useOrientation } from 'thecore-auth';
+```
+
+## Parameters
+
+This hook accepts no parameters.
+
+## Return value
+
+| Type | Values | Description |
+|------|--------|-------------|
+| `string` | `"landscape"` \| `"portrait"` | Current orientation. `"landscape"` when width > height, `"portrait"` otherwise. |
+
+## Usage
+
+```jsx
+import { useOrientation } from 'thecore-auth';
+
+function OrientationBanner() {
+  const orientation = useOrientation();
+
+  if (orientation === 'portrait') {
+    return (
+      <div className="rotate-prompt">
+        Please rotate your device to landscape mode.
+      </div>
+    );
+  }
+
+  return (
+    <main>
+      <p>Content displayed in landscape orientation.</p>
+    </main>
+  );
+}
+```
+
+## Notes
+
+- Orientation is derived from window dimensions, not from the `screen.orientation` API, so it reacts to any resize — including browser window resizing on desktop.
+- The initial value is computed synchronously from `window.innerWidth` and `window.innerHeight` at the time the hook is first called.
+- The event listener is attached to `resize` and cleaned up on unmount, so there are no memory leaks.
+- On iOS Safari, orientation changes can fire a `resize` event with a slight delay. Consider debouncing if precision timing matters.

--- a/docs/hooks/useSafeArea.md
+++ b/docs/hooks/useSafeArea.md
@@ -1,0 +1,57 @@
+# useSafeArea
+
+> [Versione italiana](../../it/hooks/useSafeArea.md) | [Versión española](../../es/hooks/useSafeArea.md)
+
+## Overview
+
+`useSafeArea` manages the `with-safe-area` CSS class on `document.body`. When the current route is **not** in the exclusion list, the class is added so that safe-area insets (e.g. iPhone notch / home bar) are respected. The class is removed on excluded routes (typically the login page) where full-bleed layouts are desired.
+
+## Import
+
+```js
+import { useSafeArea } from 'thecore-auth';
+```
+
+## Parameters
+
+| Name | Type | Default | Description |
+|------|------|---------|-------------|
+| `excludedPaths` | `string[]` | `["/"]` | Array of exact pathnames where the safe-area class should **not** be applied. |
+
+## Return value
+
+This hook returns nothing (`void`). It operates as a side effect only.
+
+## Usage
+
+```jsx
+import { useSafeArea } from 'thecore-auth';
+
+function App() {
+  // Apply safe-area everywhere except the login and splash pages
+  useSafeArea(['/', '/splash']);
+
+  return (
+    <Routes>
+      <Route path="/"       element={<Login />} />
+      <Route path="/splash" element={<Splash />} />
+      <Route path="/app"    element={<Dashboard />} />
+    </Routes>
+  );
+}
+```
+
+```css
+/* In your global CSS, define what with-safe-area means */
+.with-safe-area {
+  padding-bottom: env(safe-area-inset-bottom);
+  padding-top:    env(safe-area-inset-top);
+}
+```
+
+## Notes
+
+- Must be called inside a component that is a descendant of `<BrowserRouter>` (or equivalent), because it relies on `useLocation`.
+- Path matching is an exact string comparison (`includes`). Dynamic segments (e.g. `/user/123`) are **not** matched by a pattern like `/user/:id` — list the literal paths that should be excluded.
+- The class is removed in the effect cleanup, so navigating away from a route always starts with a clean state before the new effect runs.
+- If `document.body` class manipulation conflicts with other libraries, consider using a CSS variable or data attribute approach instead and adapting the hook.

--- a/docs/hooks/useStorage.md
+++ b/docs/hooks/useStorage.md
@@ -1,0 +1,67 @@
+# useStorage
+
+> [Versione italiana](../../it/hooks/useStorage.md) | [Versión española](../../es/hooks/useStorage.md)
+
+## Overview
+
+`useStorage` is a `useState`-compatible hook that keeps a value in sync with `localStorage`. On mount it reads the stored value (or writes the initial value if the key is absent). The returned setter persists every update automatically.
+
+## Import
+
+```js
+import { useStorage } from 'thecore-auth';
+```
+
+## Parameters
+
+| Name | Type | Default | Description |
+|------|------|---------|-------------|
+| `initialValue` | `any` | — | Value written to `localStorage` when the key does not exist yet. |
+| `itemKey` | `string` | — | `localStorage` key under which the value is stored (JSON-serialised). |
+
+## Return value
+
+Returns a tuple of three elements:
+
+| Index | Value | Type | Description |
+|-------|-------|------|-------------|
+| `0` | `state` | `any` | Current value, initialised from `localStorage`. |
+| `1` | `changeState` | `(value \| (prev) => value) => void` | Setter that updates both React state and `localStorage`. Accepts a value or an updater function. |
+| `2` | `remove` | `(clearAll?: boolean) => void` | Removes the key from `localStorage` and resets state to `initialValue`. Pass `true` to call `localStorage.clear()` instead. |
+
+## Usage
+
+```jsx
+import { useStorage } from 'thecore-auth';
+
+function ThemeToggle() {
+  const [theme, setTheme, removeTheme] = useStorage('light', 'app-theme');
+
+  return (
+    <div>
+      <p>Current theme: {theme}</p>
+
+      <button onClick={() => setTheme(t => t === 'light' ? 'dark' : 'light')}>
+        Toggle theme
+      </button>
+
+      {/* Removes only the 'app-theme' key */}
+      <button onClick={() => removeTheme()}>
+        Reset theme
+      </button>
+
+      {/* Clears ALL localStorage — use with caution */}
+      <button onClick={() => removeTheme(true)}>
+        Clear all storage
+      </button>
+    </div>
+  );
+}
+```
+
+## Notes
+
+- Values are JSON-serialised before storage and parsed on read. Non-serialisable values (e.g. functions, `undefined`) will not round-trip correctly.
+- If `localStorage` is unavailable (e.g. private browsing with storage blocked), the hook logs the error and falls back to `initialValue` without throwing.
+- `changeState` accepts an updater function `(prev) => newValue`, making it compatible with patterns that depend on the previous state.
+- `remove(true)` calls `localStorage.clear()`, which removes **all** keys — not just those managed by this hook. Use with caution.

--- a/docs/hooks/useToast.md
+++ b/docs/hooks/useToast.md
@@ -1,0 +1,76 @@
+# useToast
+
+> [Versione italiana](../../it/hooks/useToast.md) | [Versión española](../../es/hooks/useToast.md)
+
+## Overview
+
+`useToast` provides a typed interface around the [Sileo](https://github.com/sileo-js/sileo) notification library. It exposes one function per toast variant — `success`, `error`, `info`, `warning`, and `promise` — so that components can display feedback messages without importing Sileo directly.
+
+## Import
+
+```js
+import { useToast } from 'thecore-auth';
+```
+
+## Parameters
+
+This hook accepts no parameters.
+
+## Return value
+
+| Key | Type | Description |
+|-----|------|-------------|
+| `success` | `(title: string, description?: string) => void` | Shows a green success toast. |
+| `error` | `(title: string, description?: string) => void` | Shows a red error toast. |
+| `info` | `(title: string, description?: string) => void` | Shows a blue info toast. |
+| `warning` | `(title: string, description?: string) => void` | Shows an orange warning toast. |
+| `promise` | `(promise: Promise, messages: SileoPromiseMessages) => void` | Shows a loading toast that transitions to success or error based on the promise outcome. |
+
+## Usage
+
+```jsx
+import { useToast } from 'thecore-auth';
+
+function SaveButton({ onSave }) {
+  const toast = useToast();
+
+  const handleClick = async () => {
+    try {
+      await toast.promise(
+        onSave(),
+        {
+          loading: 'Saving...',
+          success: { title: 'Saved', description: 'Your changes were saved.' },
+          error:   { title: 'Error',  description: 'Could not save. Try again.' },
+        }
+      );
+    } catch {
+      toast.error('Unexpected error', 'Please contact support.');
+    }
+  };
+
+  return <button onClick={handleClick}>Save</button>;
+}
+
+// Simple feedback example
+function DeleteButton({ onDelete }) {
+  const { success, error } = useToast();
+
+  const handleDelete = async () => {
+    try {
+      await onDelete();
+      success('Deleted', 'The item was removed successfully.');
+    } catch {
+      error('Delete failed', 'The item could not be removed.');
+    }
+  };
+
+  return <button onClick={handleDelete}>Delete</button>;
+}
+```
+
+## Notes
+
+- Sileo must be configured in the application root (e.g. `<SileoProvider />`) for toasts to render. `useToast` only wraps the imperative API — it does not mount the container.
+- The `promise` method reflects the `sileo.promise` signature. Refer to the Sileo documentation for the exact shape of the `messages` argument.
+- All returned functions are recreated on every render (no `useCallback`). If you pass them as props or use them in `useEffect` dependencies, memoize at the call site if needed.

--- a/docs/hooks/useViewportHeight.md
+++ b/docs/hooks/useViewportHeight.md
@@ -1,0 +1,72 @@
+# useViewportHeight
+
+> [Versione italiana](../../it/hooks/useViewportHeight.md) | [Versión española](../../es/hooks/useViewportHeight.md)
+
+## Overview
+
+`useViewportHeight` solves the "100vh problem" on mobile browsers where the address bar shrinks and grows, causing layout jumps. It sets the CSS custom property `--vh` (equal to 1% of the actual visible viewport height) and optionally returns the raw pixel values for use in JavaScript.
+
+## Import
+
+```js
+import { useViewportHeight } from 'thecore-auth';
+```
+
+## Parameters
+
+| Name | Type | Default | Description |
+|------|------|---------|-------------|
+| `options` | `{ getValues?: boolean }` | `{ getValues: false }` | When `getValues` is `true`, the hook also tracks the viewport height in React state and returns numeric values. |
+
+## Return value
+
+When `options.getValues` is `false` (default):
+
+| Type | Description |
+|------|-------------|
+| `null` | Returns nothing. Only the `--vh` CSS property is updated. |
+
+When `options.getValues` is `true`:
+
+| Key | Type | Description |
+|-----|------|-------------|
+| `height` | `number` | Current visible viewport height in pixels. |
+| `vh` | `number` | `height * 0.01` — equivalent to `1vh` in pixels. |
+
+## Usage
+
+```jsx
+import { useViewportHeight } from 'thecore-auth';
+
+// CSS-only usage — no JS values needed
+function AppLayout({ children }) {
+  useViewportHeight(); // sets --vh, returns null
+
+  return (
+    // Use calc(var(--vh) * 100) instead of 100vh in CSS
+    <div style={{ height: 'calc(var(--vh, 1vh) * 100)' }}>
+      {children}
+    </div>
+  );
+}
+
+// JS values usage — e.g. for canvas sizing
+function FullscreenCanvas() {
+  const { height, vh } = useViewportHeight({ getValues: true });
+
+  return (
+    <canvas
+      width={window.innerWidth}
+      height={height}
+      style={{ display: 'block' }}
+    />
+  );
+}
+```
+
+## Notes
+
+- `--vh` is set on `document.documentElement`, so it is available globally in your CSS as `var(--vh)`. Use `calc(var(--vh) * 100)` where you would normally write `100vh`.
+- The hook uses `window.visualViewport.height` when available (modern browsers), falling back to `window.innerHeight`. `visualViewport` correctly excludes the on-screen keyboard on iOS and Android.
+- Event listeners for `resize` and `orientationchange` are registered on mount and removed on unmount.
+- When `getValues` is `false`, no React state is updated on resize, keeping re-renders to zero. Only switch to `{ getValues: true }` when you genuinely need numeric values in JavaScript.

--- a/docs/it/hooks/UsePageTitle.md
+++ b/docs/it/hooks/UsePageTitle.md
@@ -1,0 +1,60 @@
+# UsePageTitle
+
+> [English](../../../docs/hooks/UsePageTitle.md) | [Versión española](../../es/hooks/UsePageTitle.md)
+
+## Panoramica
+
+`UsePageTitle` aggiorna automaticamente `document.title` in base alla rotta corrente. Confronta il percorso attivo con una lista di definizioni di rotte — inclusi segmenti dinamici come `/dashboard/:id` — e imposta di conseguenza il titolo del tab.
+
+## Importazione
+
+```js
+import { UsePageTitle } from 'thecore-auth';
+```
+
+## Parametri
+
+| Nome | Tipo | Default | Descrizione |
+|------|------|---------|-------------|
+| `routes` | `Array<{ path: string, title: string }>` | `[]` | Definizioni di rotte che associano un pattern di percorso a un titolo di pagina. Supporta i segmenti dinamici di React Router. |
+| `defaultTitle` | `string` | `"SPOT"` | Titolo usato quando nessuna rotta corrisponde al percorso corrente. |
+
+## Valore restituito
+
+Questo hook non restituisce nulla (`void`). Opera solo come effetto collaterale.
+
+## Utilizzo
+
+```jsx
+import { UsePageTitle } from 'thecore-auth';
+
+const PAGE_TITLES = [
+  { path: '/',               title: 'Login' },
+  { path: '/dashboard',      title: 'Dashboard' },
+  { path: '/dashboard/:id',  title: 'Task Detail' },
+  { path: '/profile',        title: 'Il mio profilo' },
+  { path: '/settings',       title: 'Impostazioni' },
+];
+
+function AppRoutes() {
+  // Sets document.title on every navigation, falls back to "SPOT"
+  UsePageTitle(PAGE_TITLES, 'SPOT');
+
+  return (
+    <Routes>
+      <Route path="/" element={<Login />} />
+      <Route path="/dashboard" element={<Dashboard />} />
+      <Route path="/dashboard/:id" element={<TaskDetail />} />
+      <Route path="/profile" element={<Profile />} />
+      <Route path="/settings" element={<Settings />} />
+    </Routes>
+  );
+}
+```
+
+## Note
+
+- Deve essere chiamato all'interno di un componente che è discendente di `<BrowserRouter>` (o equivalente), poiché dipende da `useLocation`.
+- Usa `matchPath` con `end: true`, quindi `/dashboard` non corrisponde a `/dashboard/123`. Aggiungere voci esplicite per i segmenti dinamici quando necessario.
+- L'aggiornamento avviene all'interno di `useLayoutEffect` per evitare un flash del titolo precedente durante la navigazione.
+- L'hook è esportato con la `U` maiuscola (`UsePageTitle`) — ciò è intenzionale e corrisponde alla convenzione di denominazione del sorgente.

--- a/docs/it/hooks/useAuthStorage.md
+++ b/docs/it/hooks/useAuthStorage.md
@@ -1,0 +1,63 @@
+# useAuthStorage
+
+> [English](../../../docs/hooks/useAuthStorage.md) | [Versión española](../../es/hooks/useAuthStorage.md)
+
+## Panoramica
+
+`useAuthStorage` gestisce i due valori di autenticazione memorizzati in `localStorage` — il token di accesso e l'oggetto utente — attraverso un'interfaccia unificata. È costruito sopra [`useStorage`](./useStorage.md) ed è usato internamente da `AuthProvider`.
+
+## Importazione
+
+```js
+import { useAuthStorage } from 'thecore-auth';
+```
+
+## Parametri
+
+Questo hook non accetta parametri.
+
+## Valore restituito
+
+| Chiave | Tipo | Descrizione |
+|--------|------|-------------|
+| `token` | `string | null` | Token JWT di accesso letto dalla chiave `localStorage` `"accessToken"`. |
+| `user` | `object | null` | Oggetto utente letto dalla chiave `localStorage` `"user"`. |
+| `setToken` | `(value) => void` | Persiste un nuovo token di accesso nello stato e in `localStorage`. |
+| `setUser` | `(value) => void` | Persiste un nuovo oggetto utente nello stato e in `localStorage`. |
+| `storageLogout` | `() => void` | Rimuove sia `"accessToken"` che `"user"` da `localStorage` e reimposta lo stato a `null`. |
+
+## Utilizzo
+
+```jsx
+import { useAuthStorage } from 'thecore-auth';
+
+function SessionPanel() {
+  const { token, user, setToken, setUser, storageLogout } = useAuthStorage();
+
+  const handleLogin = (authResponse) => {
+    setToken(authResponse.accessToken);
+    setUser(authResponse.user);
+  };
+
+  const handleLogout = () => {
+    storageLogout(); // clears both token and user from localStorage
+  };
+
+  if (!token) {
+    return <button onClick={() => handleLogin({ accessToken: 'abc', user: { name: 'Alice' } })}>Accedi</button>;
+  }
+
+  return (
+    <div>
+      <p>Connesso come {user?.name}</p>
+      <button onClick={handleLogout}>Disconnetti</button>
+    </div>
+  );
+}
+```
+
+## Note
+
+- `token` e `user` vengono inizializzati da `localStorage` al primo render, quindi la sessione sopravvive ai refresh di pagina.
+- `storageLogout` chiama `removeToken()` e `removeUser()` individualmente; **non** chiama `localStorage.clear()`, quindi le chiavi non correlate vengono preservate.
+- Preferire il consumo dello stato di autenticazione tramite `useAuth` (l'hook `AuthContext`) piuttosto che chiamare direttamente `useAuthStorage` — `AuthProvider` gestisce già questi valori per te.

--- a/docs/it/hooks/useCalendar.md
+++ b/docs/it/hooks/useCalendar.md
@@ -1,0 +1,78 @@
+# useCalendar
+
+> [English](../../../docs/hooks/useCalendar.md) | [Versión española](../../es/hooks/useCalendar.md)
+
+## Panoramica
+
+`useCalendar` fornisce dati sulle festività e funzioni di utilità del calendario per un dato anno e paese. Usa la libreria [`date-holidays`](https://github.com/commenthol/date-holidays) per caricare l'elenco delle festività, espone una Map per ricerche veloci e offre helper per generare settimane, mesi e intervalli di date arbitrari.
+
+## Importazione
+
+```js
+import { useCalendar } from 'thecore-auth';
+```
+
+## Parametri
+
+| Nome | Tipo | Default | Descrizione |
+|------|------|---------|-------------|
+| `year` | `number` | anno corrente | L'anno per cui vengono caricate le festività. |
+| `country` | `string` | `"IT"` | Codice paese ISO 3166-1 alpha-2 usato da `date-holidays`. |
+
+## Valore restituito
+
+| Chiave | Tipo | Descrizione |
+|--------|------|-------------|
+| `holidays` | `object[]` | Oggetti festività grezzi restituiti da `date-holidays` per l'anno configurato. |
+| `holidayMap` | `Map<string, object>` | Map con chiave `"YYYY-MM-DD"` per ricerca O(1) delle festività. |
+| `isTodayHoliday` | `() => boolean` | Restituisce `true` se oggi è una festività. |
+| `isHoliday` | `(date: Date | string) => boolean` | Restituisce `true` se la data fornita è una festività. Accetta un oggetto `Date` o una stringa nel formato `"YYYY-MM-DD"` o `"DD/MM/YYYY"`. |
+| `getWeekDays` | `(date: Date | string) => Date[]` | Restituisce un array di 7 oggetti `Date` per la settimana da lunedì a domenica contenente `date`. |
+| `getWeeksInMonth` | `(month: number, year?: number) => Date[][]` | Restituisce un array di settimane, ciascuna un `Date[]` di 7 elementi, che coprono il mese dato (con indice 0). |
+| `getDaysInMonth` | `(month: number, year?: number) => Date[]` | Restituisce tutti i giorni del mese dato come `Date[]`. |
+| `getDaysInMonths` | `(startMonth: number, startYear?: number, numMonths?: number) => Date[]` | Restituisce tutti i giorni in `numMonths` mesi consecutivi a partire da `startMonth`. |
+| `getDaysInYear` | `(year: number) => Date[]` | Restituisce tutti i 365/366 giorni dell'anno dato come `Date[]`. |
+
+## Utilizzo
+
+```jsx
+import { useCalendar } from 'thecore-auth';
+
+function MonthView({ month, year }) {
+  const { getWeeksInMonth, isHoliday, isTodayHoliday } = useCalendar(year, 'IT');
+
+  const weeks = getWeeksInMonth(month, year);
+  const today = new Date().toDateString();
+
+  return (
+    <div>
+      {isTodayHoliday() && <p>Oggi è un giorno festivo!</p>}
+      {weeks.map((week, wi) => (
+        <div key={wi} style={{ display: 'flex' }}>
+          {week.map((day, di) => (
+            <div
+              key={di}
+              style={{
+                background: isHoliday(day) ? '#fdd' : day.toDateString() === today ? '#dfd' : '#fff',
+                border: '1px solid #ccc',
+                padding: '4px 8px',
+                minWidth: 36,
+                textAlign: 'center',
+              }}
+            >
+              {day.getDate()}
+            </div>
+          ))}
+        </div>
+      ))}
+    </div>
+  );
+}
+```
+
+## Note
+
+- Le festività vengono caricate in modo asincrono all'interno di un `useEffect`. L'array `holidays` e `holidayMap` sono vuoti al primo render e popolati una volta che l'effetto viene eseguito. Fare attenzione a questo se si esegue il rendering immediatamente al mount.
+- `getDaysInMonths` gestisce il cambio di anno: partendo dal mese `10` con `numMonths = 6` si estende correttamente nell'anno successivo.
+- `getWeeksInMonth` può includere giorni del mese precedente o successivo per completare le prime e ultime settimane della griglia. Controllare `day.getMonth() !== month` se si vogliono nascondere i giorni fuori dal mese.
+- Le chiavi delle date in `holidayMap` sono derivate dall'ora locale (non UTC), quindi corrispondono correttamente indipendentemente dall'offset del fuso orario dell'utente.

--- a/docs/it/hooks/useClickOutside.md
+++ b/docs/it/hooks/useClickOutside.md
@@ -1,0 +1,69 @@
+# useClickOutside
+
+> [English](../../../docs/hooks/useClickOutside.md) | [Versión española](../../es/hooks/useClickOutside.md)
+
+## Panoramica
+
+`useClickOutside` chiama una callback ogni volta che l'utente clicca (o tocca) al di fuori di un elemento DOM referenziato. È il blocco di costruzione standard per chiudere dropdown, modali, popover e menu contestuali al click esterno.
+
+## Importazione
+
+```js
+import { useClickOutside } from 'thecore-auth';
+```
+
+## Parametri
+
+| Nome | Tipo | Default | Descrizione |
+|------|------|---------|-------------|
+| `ref` | `React.RefObject<HTMLElement>` | — | Ref collegato all'elemento che definisce l'area "interna". |
+| `callback` | `() => void` | — | Funzione chiamata quando un evento `mousedown` si verifica al di fuori dell'elemento ref. |
+
+## Valore restituito
+
+Questo hook non restituisce nulla (`void`). Opera solo come effetto collaterale.
+
+## Utilizzo
+
+```jsx
+import { useRef } from 'react';
+import { useClickOutside } from 'thecore-auth';
+
+function Dropdown({ isOpen, onClose, children }) {
+  const ref = useRef(null);
+
+  // Close the dropdown whenever the user clicks outside
+  useClickOutside(ref, onClose);
+
+  if (!isOpen) return null;
+
+  return (
+    <div ref={ref} className="dropdown-panel">
+      {children}
+    </div>
+  );
+}
+
+// Usage in a parent component
+function NavBar() {
+  const [open, setOpen] = React.useState(false);
+
+  return (
+    <nav>
+      <button onClick={() => setOpen(o => !o)}>Menu</button>
+      <Dropdown isOpen={open} onClose={() => setOpen(false)}>
+        <a href="/profile">Profilo</a>
+        <a href="/settings">Impostazioni</a>
+        <a href="/logout">Disconnetti</a>
+      </Dropdown>
+    </nav>
+  );
+}
+```
+
+## Note
+
+- L'hook ascolta `mousedown`, non `click`. Questo si attiva prima dell'evento click, il che impedisce al gestore `click` del pulsante trigger di riaprire un elemento appena chiuso.
+- `callback` e `ref` sono elencati come dipendenze dell'effetto. Se `callback` non è memorizzata con `useCallback`, il listener verrà rimosso e riaggiunto ad ogni render. Racchiudere la callback in `useCallback` al punto di chiamata quando questo è rilevante.
+- Il listener è collegato a `document`, quindi cattura gli eventi che risalgono fino in cima. Gli elementi che interrompono la propagazione con `e.stopPropagation()` in un gestore `mousedown` impediranno l'esecuzione della callback.
+- Gli eventi touch non vengono gestiti esplicitamente; `mousedown` si attiva sui dispositivi touch attraverso il sistema di eventi sintetici, quindi l'hook funziona su mobile senza modifiche.

--- a/docs/it/hooks/useDevice.md
+++ b/docs/it/hooks/useDevice.md
@@ -1,0 +1,64 @@
+# useDevice
+
+> [English](../../../docs/hooks/useDevice.md) | [Versión española](../../es/hooks/useDevice.md)
+
+## Panoramica
+
+`useDevice` analizza la stringa User-Agent corrente tramite `ua-parser-js` e restituisce un oggetto stabile che descrive il tipo di dispositivo, OS, browser e flag booleani di convenienza. Il risultato viene calcolato una volta e memorizzato nella cache a livello di modulo, quindi le chiamate successive (anche tra componenti diversi) condividono lo stesso oggetto senza rieseguire il parsing.
+
+## Importazione
+
+```js
+import { useDevice } from 'thecore-auth';
+```
+
+## Parametri
+
+Questo hook non accetta parametri.
+
+## Valore restituito
+
+| Chiave | Tipo | Descrizione |
+|--------|------|-------------|
+| `type` | `string` | Tipo di dispositivo: `"mobile"`, `"tablet"` o `"desktop"`. |
+| `os` | `string | undefined` | Nome del sistema operativo (es. `"iOS"`, `"Android"`, `"Windows"`). |
+| `browser` | `string | undefined` | Nome del browser (es. `"Chrome"`, `"Safari"`, `"Firefox"`). |
+| `vendor` | `string | null` | Produttore del dispositivo (es. `"Apple"`, `"Samsung"`), o `null` se sconosciuto. |
+| `model` | `string | null` | Modello del dispositivo (es. `"iPhone"`, `"iPad"`), o `null` se sconosciuto. |
+| `isMobile` | `boolean` | `true` per i telefoni. |
+| `isTablet` | `boolean` | `true` per i tablet, inclusi gli iPad mascherati da desktop da Safari. |
+| `isDesktop` | `boolean` | `true` quando non è né mobile né tablet. |
+| `isIPhone` | `boolean` | `true` quando il modello del dispositivo è `"iPhone"`. |
+| `isIPad` | `boolean` | `true` per gli iPad, inclusi quelli in cui Safari riporta `MacIntel`. |
+| `isAndroid` | `boolean` | `true` quando il sistema operativo è `"Android"`. |
+
+## Utilizzo
+
+```jsx
+import { useDevice } from 'thecore-auth';
+
+function AdaptiveLayout({ children }) {
+  const { isMobile, isTablet, isDesktop, os } = useDevice();
+
+  return (
+    <div
+      className={
+        isMobile  ? 'layout-mobile'  :
+        isTablet  ? 'layout-tablet'  :
+                    'layout-desktop'
+      }
+    >
+      {isDesktop && <Sidebar />}
+      <main>{children}</main>
+      {isMobile && os === 'iOS' && <IOSInstallBanner />}
+    </div>
+  );
+}
+```
+
+## Note
+
+- L'UA viene analizzato al massimo una volta per caricamento di pagina. Il risultato è memorizzato in una variabile a livello di modulo (`cachedDevice`), quindi chiamare `useDevice` in più componenti è gratuito dopo la prima chiamata.
+- Il rilevamento dell'iPad include un fallback per Safari ≥ 13 su iPadOS, che riporta `MacIntel` come piattaforma. L'hook controlla `navigator.platform === "MacIntel" && "ontouchend" in document` per identificare questi dispositivi.
+- Poiché il risultato è memorizzato nella cache, non cambia in modo reattivo. Se l'hook viene usato in un contesto di server-side rendering, `navigator` / `document` non saranno disponibili e l'hook lancerà un'eccezione.
+- `useMemo` con un array di dipendenze vuoto è usato per garantire la stabilità referenziale; l'oggetto restituito è sempre lo stesso riferimento memorizzato nella cache.

--- a/docs/it/hooks/useForm.md
+++ b/docs/it/hooks/useForm.md
@@ -1,0 +1,89 @@
+# useForm
+
+> [English](../../../docs/hooks/useForm.md) | [Versión española](../../es/hooks/useForm.md)
+
+## Panoramica
+
+`useForm` gestisce lo stato di un form che può contenere sia valori di campi primitivi che upload di file. Gestisce le modifiche ai campi, l'aggiunta, la sostituzione e la rimozione di file, e genera automaticamente URL di anteprima degli oggetti per i file immagine.
+
+## Importazione
+
+```js
+import { useForm } from 'thecore-auth';
+```
+
+## Parametri
+
+| Nome | Tipo | Default | Descrizione |
+|------|------|---------|-------------|
+| `initialValues` | `object` | `{}` | Valori iniziali per tutti i campi non-file, con chiave per nome del campo. |
+
+## Valore restituito
+
+| Chiave | Tipo | Descrizione |
+|--------|------|-------------|
+| `values` | `object` | Valori correnti dei campi non-file. |
+| `handleChange` | `(field: string, value: any) => void` | Aggiorna il valore di un singolo campo. |
+| `files` | `object` | Mappa nome campo → `File[]` per i file caricati. |
+| `previews` | `object` | Mappa nome campo → `string[]` di URL oggetto per l'anteprima delle immagini. |
+| `addFiles` | `(field: string, fileList: FileList | File[]) => void` | Aggiunge nuovi file a una lista esistente senza sostituire quelli precedenti. |
+| `replaceFiles` | `(field: string, fileList: FileList | File[]) => void` | Sostituisce completamente la lista dei file per un campo. |
+| `removeFile` | `(field: string, index: number) => void` | Rimuove un singolo file e la sua anteprima per indice. |
+| `setValues` | `React.Dispatch` | Setter dello stato diretto per `values` — usare per aggiornamenti in blocco. |
+| `resetForm` | `() => void` | Reimposta `values` a `initialValues` e cancella tutti i file e le anteprime. |
+
+## Utilizzo
+
+```jsx
+import { useForm } from 'thecore-auth';
+
+function ProfileForm({ onSubmit }) {
+  const { values, handleChange, files, previews, addFiles, removeFile, resetForm } = useForm({
+    username: '',
+    bio: '',
+  });
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    const formData = new FormData();
+    formData.append('username', values.username);
+    formData.append('bio', values.bio);
+    (files.avatar || []).forEach(f => formData.append('avatar', f));
+    onSubmit(formData);
+  };
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <input
+        value={values.username}
+        onChange={e => handleChange('username', e.target.value)}
+        placeholder="Username"
+      />
+      <textarea
+        value={values.bio}
+        onChange={e => handleChange('bio', e.target.value)}
+        placeholder="Bio"
+      />
+      <input type="file" accept="image/*"
+        onChange={e => addFiles('avatar', e.target.files)} />
+
+      {(previews.avatar || []).map((url, i) => (
+        <div key={i}>
+          <img src={url} alt="anteprima" width={80} />
+          <button type="button" onClick={() => removeFile('avatar', i)}>Rimuovi</button>
+        </div>
+      ))}
+
+      <button type="submit">Salva</button>
+      <button type="button" onClick={resetForm}>Reimposta</button>
+    </form>
+  );
+}
+```
+
+## Note
+
+- Gli URL degli oggetti creati da `addFiles` e `replaceFiles` **non** vengono revocati automaticamente. Chiamare `URL.revokeObjectURL(url)` quando l'anteprima non è più necessaria per evitare memory leak, specialmente quando gli utenti caricano molti file di grandi dimensioni.
+- `handleChange` imposta un singolo campo; per aggiornamenti in blocco dei valori usare direttamente il dispatcher `setValues` restituito.
+- `files` e `values` vengono tracciati in oggetti di stato separati, quindi l'aggiornamento dei file non fa ri-renderizzare i componenti che consumano solo `values`, e viceversa.
+- `resetForm` ripristina `values` alla snapshot di `initialValues` catturata al momento dell'inizializzazione dell'hook — le mutazioni all'oggetto `initialValues` dopo il mount non vengono riflesse.

--- a/docs/it/hooks/useIndexedDB.md
+++ b/docs/it/hooks/useIndexedDB.md
@@ -1,0 +1,81 @@
+# useIndexedDB
+
+> [English](../../../docs/hooks/useIndexedDB.md) | [Versión española](../../es/hooks/useIndexedDB.md)
+
+## Panoramica
+
+`useIndexedDB` apre un database IndexedDB ed espone un'interfaccia CRUD basata su Promise per un singolo object store. La connessione al database viene aperta al mount e chiusa all'unmount. Un flag `isReady` segnala quando il database è aperto e le operazioni possono essere eseguite in sicurezza.
+
+## Importazione
+
+```js
+import { useIndexedDB } from 'thecore-auth';
+```
+
+## Parametri
+
+| Nome | Tipo | Default | Descrizione |
+|------|------|---------|-------------|
+| `dbName` | `string` | — | Nome del database IndexedDB da aprire o creare. |
+| `storeName` | `string` | — | Nome dell'object store da usare nel database. Creato automaticamente alla prima apertura. |
+| `version` | `number` | `1` | Versione dello schema del database. Incrementare per innescare una migrazione `onupgradeneeded`. |
+
+## Valore restituito
+
+| Chiave | Tipo | Descrizione |
+|--------|------|-------------|
+| `isReady` | `boolean` | `true` una volta che la connessione al database è aperta e le operazioni possono essere eseguite. |
+| `get` | `(key: any) => Promise<any>` | Recupera il record corrispondente alla chiave primaria. Risolve `undefined` se non trovato. |
+| `getAll` | `() => Promise<any[]>` | Recupera tutti i record nello store. |
+| `set` | `(data: object) => Promise<IDBValidKey>` | Inserisce o aggiorna un record. L'oggetto `data` deve includere il campo `id` (keyPath). |
+| `setWithAutoId` | `(data: object) => Promise<IDBValidKey>` | Come `set`, ma genera automaticamente un `id` numerico univoco se `data.id` è assente. |
+| `remove` | `(id: any) => Promise<true>` | Elimina il record con la chiave primaria specificata. |
+| `clear` | `() => Promise<true>` | Elimina tutti i record nello store. |
+
+## Utilizzo
+
+```jsx
+import { useIndexedDB } from 'thecore-auth';
+
+function NoteList() {
+  const { isReady, getAll, setWithAutoId, remove } = useIndexedDB('notesDB', 'notes');
+  const [notes, setNotes] = React.useState([]);
+
+  // Load all notes once the DB is open
+  React.useEffect(() => {
+    if (!isReady) return;
+    getAll().then(setNotes);
+  }, [isReady, getAll]);
+
+  const addNote = async () => {
+    await setWithAutoId({ text: 'Nuova nota', createdAt: Date.now() });
+    setNotes(await getAll());
+  };
+
+  const deleteNote = async (id) => {
+    await remove(id);
+    setNotes(await getAll());
+  };
+
+  return (
+    <div>
+      <button onClick={addNote}>Aggiungi nota</button>
+      <ul>
+        {notes.map(n => (
+          <li key={n.id}>
+            {n.text} <button onClick={() => deleteNote(n.id)}>Elimina</button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+```
+
+## Note
+
+- L'object store viene creato con `keyPath: "id"` alla prima apertura. I record devono includere un campo `id` quando si usa direttamente `set`.
+- `setWithAutoId` genera ID usando `Date.now()` e incrementa fino a trovare un valore senza collisioni — adatto per scritture a basso volume; non raccomandato per scenari ad alta concorrenza.
+- Tutte le operazioni rifiutano con una stringa di errore (`"DB non pronto"`) se chiamate prima che `isReady` sia `true`.
+- Per ogni istanza dell'hook viene gestito un solo object store. Per più store, istanziare l'hook più volte con lo stesso `dbName` e diversi valori `storeName`.
+- La connessione al database viene chiusa automaticamente quando il componente viene smontato.

--- a/docs/it/hooks/useOrientation.md
+++ b/docs/it/hooks/useOrientation.md
@@ -1,0 +1,54 @@
+# useOrientation
+
+> [English](../../../docs/hooks/useOrientation.md) | [Versión española](../../es/hooks/useOrientation.md)
+
+## Panoramica
+
+`useOrientation` restituisce l'orientamento corrente dello schermo come stringa e si aggiorna in modo reattivo ogni volta che la finestra viene ridimensionata. L'orientamento viene determinato confrontando `window.innerWidth` e `window.innerHeight`.
+
+## Importazione
+
+```js
+import { useOrientation } from 'thecore-auth';
+```
+
+## Parametri
+
+Questo hook non accetta parametri.
+
+## Valore restituito
+
+| Tipo | Valori | Descrizione |
+|------|--------|-------------|
+| `string` | `"landscape"` | `"portrait"` | Orientamento corrente. `"landscape"` quando larghezza > altezza, `"portrait"` altrimenti. |
+
+## Utilizzo
+
+```jsx
+import { useOrientation } from 'thecore-auth';
+
+function OrientationBanner() {
+  const orientation = useOrientation();
+
+  if (orientation === 'portrait') {
+    return (
+      <div className="rotate-prompt">
+        Ruota il dispositivo in modalità orizzontale.
+      </div>
+    );
+  }
+
+  return (
+    <main>
+      <p>Contenuto visualizzato in orientamento orizzontale.</p>
+    </main>
+  );
+}
+```
+
+## Note
+
+- L'orientamento è derivato dalle dimensioni della finestra, non dall'API `screen.orientation`, quindi reagisce a qualsiasi ridimensionamento — incluso il ridimensionamento della finestra del browser sul desktop.
+- Il valore iniziale viene calcolato in modo sincrono da `window.innerWidth` e `window.innerHeight` al momento della prima chiamata dell'hook.
+- Il listener di eventi è collegato a `resize` e rimosso all'unmount, quindi non ci sono memory leak.
+- Su iOS Safari, i cambi di orientamento possono innescare un evento `resize` con un leggero ritardo. Considerare il debouncing se la precisione temporale è importante.

--- a/docs/it/hooks/useSafeArea.md
+++ b/docs/it/hooks/useSafeArea.md
@@ -1,0 +1,57 @@
+# useSafeArea
+
+> [English](../../../docs/hooks/useSafeArea.md) | [Versión española](../../es/hooks/useSafeArea.md)
+
+## Panoramica
+
+`useSafeArea` gestisce la classe CSS `with-safe-area` su `document.body`. Quando la rotta corrente **non** è nell'elenco di esclusione, la classe viene aggiunta in modo che i safe-area insets (es. notch / home bar dell'iPhone) vengano rispettati. La classe viene rimossa nelle rotte escluse (tipicamente la pagina di login) dove si desiderano layout a piena pagina.
+
+## Importazione
+
+```js
+import { useSafeArea } from 'thecore-auth';
+```
+
+## Parametri
+
+| Nome | Tipo | Default | Descrizione |
+|------|------|---------|-------------|
+| `excludedPaths` | `string[]` | `["/"]` | Array di pathname esatti dove la classe safe-area **non** deve essere applicata. |
+
+## Valore restituito
+
+Questo hook non restituisce nulla (`void`). Opera solo come effetto collaterale.
+
+## Utilizzo
+
+```jsx
+import { useSafeArea } from 'thecore-auth';
+
+function App() {
+  // Apply safe-area everywhere except the login and splash pages
+  useSafeArea(['/', '/splash']);
+
+  return (
+    <Routes>
+      <Route path="/"       element={<Login />} />
+      <Route path="/splash" element={<Splash />} />
+      <Route path="/app"    element={<Dashboard />} />
+    </Routes>
+  );
+}
+```
+
+```css
+/* In your global CSS, define what with-safe-area means */
+.with-safe-area {
+  padding-bottom: env(safe-area-inset-bottom);
+  padding-top:    env(safe-area-inset-top);
+}
+```
+
+## Note
+
+- Deve essere chiamato all'interno di un componente che è discendente di `<BrowserRouter>` (o equivalente), poiché dipende da `useLocation`.
+- La corrispondenza del percorso è un confronto esatto di stringhe (`includes`). I segmenti dinamici (es. `/user/123`) **non** vengono abbinati da un pattern come `/user/:id` — elencare i percorsi letterali da escludere.
+- La classe viene rimossa nel cleanup dell'effetto, quindi navigare lontano da una rotta inizia sempre con uno stato pulito prima che venga eseguito il nuovo effetto.
+- Se la manipolazione della classe di `document.body` entra in conflitto con altre librerie, considerare l'uso di una variabile CSS o di un approccio con attributi data e adattare l'hook di conseguenza.

--- a/docs/it/hooks/useStorage.md
+++ b/docs/it/hooks/useStorage.md
@@ -1,0 +1,67 @@
+# useStorage
+
+> [English](../../../docs/hooks/useStorage.md) | [Versión española](../../es/hooks/useStorage.md)
+
+## Panoramica
+
+`useStorage` è un hook compatibile con `useState` che mantiene un valore sincronizzato con `localStorage`. Al mount legge il valore memorizzato (o scrive il valore iniziale se la chiave è assente). Il setter restituito persiste ogni aggiornamento automaticamente.
+
+## Importazione
+
+```js
+import { useStorage } from 'thecore-auth';
+```
+
+## Parametri
+
+| Nome | Tipo | Default | Descrizione |
+|------|------|---------|-------------|
+| `initialValue` | `any` | — | Valore scritto su `localStorage` quando la chiave non esiste ancora. |
+| `itemKey` | `string` | — | Chiave `localStorage` sotto cui viene memorizzato il valore (serializzato in JSON). |
+
+## Valore restituito
+
+Restituisce una tupla di tre elementi:
+
+| Indice | Valore | Tipo | Descrizione |
+|--------|--------|------|-------------|
+| `0` | `state` | `any` | Valore corrente, inizializzato da `localStorage`. |
+| `1` | `changeState` | `(value | (prev) => value) => void` | Setter che aggiorna sia lo stato React che `localStorage`. Accetta un valore o una funzione updater. |
+| `2` | `remove` | `(clearAll?: boolean) => void` | Rimuove la chiave da `localStorage` e reimposta lo stato a `initialValue`. Passare `true` per chiamare `localStorage.clear()`. |
+
+## Utilizzo
+
+```jsx
+import { useStorage } from 'thecore-auth';
+
+function ThemeToggle() {
+  const [theme, setTheme, removeTheme] = useStorage('light', 'app-theme');
+
+  return (
+    <div>
+      <p>Tema corrente: {theme}</p>
+
+      <button onClick={() => setTheme(t => t === 'light' ? 'dark' : 'light')}>
+        Cambia tema
+      </button>
+
+      {/* Removes only the 'app-theme' key */}
+      <button onClick={() => removeTheme()}>
+        Reimposta tema
+      </button>
+
+      {/* Clears ALL localStorage — use with caution */}
+      <button onClick={() => removeTheme(true)}>
+        Svuota tutto lo storage
+      </button>
+    </div>
+  );
+}
+```
+
+## Note
+
+- I valori vengono serializzati in JSON prima della memorizzazione e analizzati alla lettura. I valori non serializzabili (es. funzioni, `undefined`) non si preserveranno correttamente.
+- Se `localStorage` non è disponibile (es. navigazione privata con storage bloccato), l'hook registra l'errore e torna a `initialValue` senza lanciare eccezioni.
+- `changeState` accetta una funzione updater `(prev) => newValue`, rendendolo compatibile con pattern che dipendono dallo stato precedente.
+- `remove(true)` chiama `localStorage.clear()`, che rimuove **tutte** le chiavi — non solo quelle gestite da questo hook. Usare con cautela.

--- a/docs/it/hooks/useToast.md
+++ b/docs/it/hooks/useToast.md
@@ -1,0 +1,76 @@
+# useToast
+
+> [English](../../../docs/hooks/useToast.md) | [Versión española](../../es/hooks/useToast.md)
+
+## Panoramica
+
+`useToast` fornisce un'interfaccia tipizzata intorno alla libreria di notifiche [Sileo](https://github.com/sileo-js/sileo). Espone una funzione per ogni variante di toast — `success`, `error`, `info`, `warning` e `promise` — in modo che i componenti possano mostrare messaggi di feedback senza importare Sileo direttamente.
+
+## Importazione
+
+```js
+import { useToast } from 'thecore-auth';
+```
+
+## Parametri
+
+Questo hook non accetta parametri.
+
+## Valore restituito
+
+| Chiave | Tipo | Descrizione |
+|--------|------|-------------|
+| `success` | `(title: string, description?: string) => void` | Mostra un toast verde di successo. |
+| `error` | `(title: string, description?: string) => void` | Mostra un toast rosso di errore. |
+| `info` | `(title: string, description?: string) => void` | Mostra un toast blu informativo. |
+| `warning` | `(title: string, description?: string) => void` | Mostra un toast arancione di avviso. |
+| `promise` | `(promise: Promise, messages: SileoPromiseMessages) => void` | Mostra un toast di caricamento che passa a successo o errore in base all'esito della promise. |
+
+## Utilizzo
+
+```jsx
+import { useToast } from 'thecore-auth';
+
+function SaveButton({ onSave }) {
+  const toast = useToast();
+
+  const handleClick = async () => {
+    try {
+      await toast.promise(
+        onSave(),
+        {
+          loading: 'Salvataggio in corso...',
+          success: { title: 'Salvato', description: 'Le modifiche sono state salvate.' },
+          error:   { title: 'Errore',  description: 'Impossibile salvare. Riprova.' },
+        }
+      );
+    } catch {
+      toast.error('Errore imprevisto', 'Contatta il supporto.');
+    }
+  };
+
+  return <button onClick={handleClick}>Salva</button>;
+}
+
+// Simple feedback example
+function DeleteButton({ onDelete }) {
+  const { success, error } = useToast();
+
+  const handleDelete = async () => {
+    try {
+      await onDelete();
+      success('Eliminato', 'L'elemento è stato rimosso con successo.');
+    } catch {
+      error('Eliminazione fallita', 'L'elemento non può essere rimosso.');
+    }
+  };
+
+  return <button onClick={handleDelete}>Elimina</button>;
+}
+```
+
+## Note
+
+- Sileo deve essere configurato nella root dell'applicazione (es. `<SileoProvider />`) per visualizzare i toast. `useToast` racchiude solo l'API imperativa — non monta il container.
+- Il metodo `promise` rispecchia la firma di `sileo.promise`. Consultare la documentazione di Sileo per la forma esatta dell'argomento `messages`.
+- Tutte le funzioni restituite vengono ricreate ad ogni render (nessun `useCallback`). Se vengono passate come props o usate nelle dipendenze di `useEffect`, memorizzare con useCallback al punto di chiamata se necessario.

--- a/docs/it/hooks/useViewportHeight.md
+++ b/docs/it/hooks/useViewportHeight.md
@@ -1,0 +1,72 @@
+# useViewportHeight
+
+> [English](../../../docs/hooks/useViewportHeight.md) | [Versión española](../../es/hooks/useViewportHeight.md)
+
+## Panoramica
+
+`useViewportHeight` risolve il problema del "100vh" sui browser mobile dove la barra degli indirizzi si rimpicciolisce e cresce, causando salti di layout. Imposta la proprietà CSS custom `--vh` (uguale all'1% dell'altezza reale della viewport visibile) e opzionalmente restituisce i valori in pixel grezzi per l'uso in JavaScript.
+
+## Importazione
+
+```js
+import { useViewportHeight } from 'thecore-auth';
+```
+
+## Parametri
+
+| Nome | Tipo | Default | Descrizione |
+|------|------|---------|-------------|
+| `options` | `{ getValues?: boolean }` | `{ getValues: false }` | Quando `getValues` è `true`, l'hook traccia anche l'altezza della viewport nello stato React e restituisce valori numerici. |
+
+## Valore restituito
+
+Quando `options.getValues` è `false` (default):
+
+| Tipo | Descrizione |
+|------|-------------|
+| `null` | Non restituisce nulla. Solo la proprietà CSS `--vh` viene aggiornata. |
+
+Quando `options.getValues` è `true`:
+
+| Chiave | Tipo | Descrizione |
+|--------|------|-------------|
+| `height` | `number` | Altezza della viewport visibile corrente in pixel. |
+| `vh` | `number` | `height * 0.01` — equivalente a `1vh` in pixel. |
+
+## Utilizzo
+
+```jsx
+import { useViewportHeight } from 'thecore-auth';
+
+// CSS-only usage — no JS values needed
+function AppLayout({ children }) {
+  useViewportHeight(); // sets --vh, returns null
+
+  return (
+    // Use calc(var(--vh) * 100) instead of 100vh in CSS
+    <div style={{ height: 'calc(var(--vh, 1vh) * 100)' }}>
+      {children}
+    </div>
+  );
+}
+
+// JS values usage — e.g. for canvas sizing
+function FullscreenCanvas() {
+  const { height, vh } = useViewportHeight({ getValues: true });
+
+  return (
+    <canvas
+      width={window.innerWidth}
+      height={height}
+      style={{ display: 'block' }}
+    />
+  );
+}
+```
+
+## Note
+
+- `--vh` è impostato su `document.documentElement`, quindi è disponibile globalmente nel CSS come `var(--vh)`. Usare `calc(var(--vh) * 100)` dove normalmente si scriverebbe `100vh`.
+- L'hook usa `window.visualViewport.height` quando disponibile (browser moderni), con fallback a `window.innerHeight`. `visualViewport` esclude correttamente la tastiera su schermo su iOS e Android.
+- I listener di eventi per `resize` e `orientationchange` vengono registrati al mount e rimossi all'unmount.
+- Quando `getValues` è `false`, nessuno stato React viene aggiornato al resize, mantenendo i re-render a zero. Passare a `{ getValues: true }` solo quando si hanno genuinamente bisogno di valori numerici in JavaScript.


### PR DESCRIPTION
## Summary
- 12 hook reference files in EN + IT + ES (36 files total)
- Schema: Overview · Import · Parameters · Return value · Usage · Notes
- Reads actual source from src/hooks/ — no guessing

Closes #10