### PR TITLE
docs(components): add input components reference docs

### DIFF
--- a/docs/components/FileDropzone.md
+++ b/docs/components/FileDropzone.md
@@ -1,0 +1,73 @@
+# FileDropzone
+
+> **Versione italiana:** [docs/it/components/FileDropzone.md](../it/components/FileDropzone.md) | **Versión española:** [docs/es/components/FileDropzone.md](../es/components/FileDropzone.md)
+
+## Overview
+
+A drag-and-drop file upload zone. It handles `dragenter`, `dragover`, `dragleave`, and `drop` events and forwards selected files — whether dragged or picked via the native file dialog — as an `Array<File>` to the `onFilesSelect` callback. An animated border overlay appears while a drag is in progress. All visual regions are customizable through dedicated style props.
+
+## Import
+
+```js
+import { FileDropzone } from 'thecore-auth';
+```
+
+## Props
+
+| Name | Type | Default | Required | Description |
+|---|---|---|---|---|
+| `onFilesSelect` | `(files: File[]) => void` | — | Yes | Called with an `Array<File>` whenever the user drops or selects files. |
+| `id` | `string` | `'dropzone-file'` | No | `id` attribute of the hidden `<input type="file">`. |
+| `containerStyle` | `string` | `'flex items-center justify-center w-full relative h-full'` | No | Class string for the outermost `<div>`. |
+| `labelStyle` | `string` | See below | No | Class string for the `<label>` that wraps the visible dropzone area. Includes drag-active state interpolation by default. |
+| `dropzoneStyle` | `string` | `'flex flex-col items-center justify-center text-body px-6 text-center pt-5 pb-6 pointer-events-none'` | No | Class string for the inner content block (icon + text). |
+| `dragActiveStyle` | `string` | `'absolute w-full h-full top-0 left-0 rounded-2xl border-2 border-primary-strong/70 animate-pulse'` | No | Class string for the overlay `<div>` rendered when a drag is in progress. |
+
+**Default `labelStyle`:**
+```
+flex flex-col items-center justify-center w-full h-full rounded-2xl transition-all
+duration-300 bg-slate-100/80 shadow-lg border border-slate-300 rounded-base
+cursor-pointer hover:bg-slate-200/80 hover:border-slate-500 hover:shadow-xl
+[drag-active: bg-slate-200/80 border-slate-600 shadow-xl shadow-primary-strong]
+```
+
+## CSS Variables
+
+`FileDropzone` does not use CSS custom properties from `src/css/index.css`. All styling is expressed through Tailwind utility classes in the default prop values.
+
+## Usage
+
+```jsx
+import { useState } from 'react';
+import { FileDropzone } from 'thecore-auth';
+
+function UploadPanel() {
+  const [files, setFiles] = useState([]);
+
+  const handleFiles = (selected) => {
+    setFiles((prev) => [...prev, ...selected]);
+  };
+
+  return (
+    <div className="h-64 w-full max-w-lg mx-auto">
+      <FileDropzone onFilesSelect={handleFiles} />
+
+      {files.length > 0 && (
+        <ul className="mt-4 text-sm text-slate-600 space-y-1">
+          {files.map((f, i) => (
+            <li key={i}>{f.name} — {(f.size / 1024).toFixed(1)} KB</li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+```
+
+## Notes
+
+- The hidden `<input type="file">` has the `multiple` attribute, so users can always select more than one file regardless of the drag-and-drop path.
+- Drag events (`dragenter`, `dragover`, `dragleave`) are managed with `useCallback` to avoid re-creating handlers on each render.
+- The drag-active overlay intercepts pointer events during a drag to prevent the cursor from leaving the dropzone boundaries; it is removed immediately on `drop` or `dragleave`.
+- The upload icon (`SlCloudUpload`) is imported from `react-icons/sl` — ensure this package is available in the consuming project.
+- UI text inside the component is currently in Italian ("Clicca per caricare…"); override `dropzoneStyle` or fork the component if you need a different locale.

--- a/docs/components/Input.md
+++ b/docs/components/Input.md
@@ -1,0 +1,92 @@
+# Input
+
+> **Versione italiana:** [docs/it/components/Input.md](../it/components/Input.md) | **Versión española:** [docs/es/components/Input.md](../es/components/Input.md)
+
+## Overview
+
+A controlled text input that wraps the native `<input>` element. It constrains `type` to a safe allow-list and applies the project's CSS-variable-driven design tokens by default. Any class can be replaced via `overrideStyle` or extended via `inputStyle`.
+
+## Import
+
+```js
+import { Input } from 'thecore-auth';
+```
+
+## Props
+
+| Name | Type | Default | Required | Description |
+|---|---|---|---|---|
+| `inputType` | `'text' \| 'email' \| 'password' \| 'search' \| 'tel' \| 'url'` | `'text'` | No | Native input type. Falls back to `'text'` if an invalid value is supplied. |
+| `inputId` | `string` | — | No | `id` attribute; pair with an `InputLabel` for accessibility. |
+| `inputName` | `string` | — | No | `name` attribute for form submission. |
+| `inputValue` | `string` | — | Yes | Controlled value. |
+| `inputChange` | `(e: ChangeEvent) => void` | — | Yes | `onChange` handler. |
+| `inputPlaceholder` | `string` | — | No | Placeholder text. |
+| `inputRequired` | `boolean` | `true` | No | Maps to the native `required` attribute. |
+| `autoFocus` | `boolean` | — | No | Auto-focuses the field on mount. |
+| `inputStyle` | `string` | `''` | No | Extra Tailwind classes appended to the default class string. |
+| `overrideStyle` | `string` | — | No | Replaces the entire default class string when provided. |
+| `disabled` | `boolean` | — | No | Disables the input. |
+
+## CSS Variables
+
+| Variable | Default | Effect |
+|---|---|---|
+| `--color-input-bg` | `#f9fafb` | Input background (`bg-input-bg`) |
+| `--color-input-border` | `#d1d5db` | Border color (`border-input-border`) |
+| `--color-input-text` | `#111827` | Text color (`text-input-text`) |
+| `--text-input-placeholder` | `14px` | Placeholder font size (`text-input-placeholder`) |
+| `--input-radius` | `8px` | Border radius (`.input-rounded`) |
+| `--padding-input` | `10px` | Internal padding (`p-input`) |
+| `--color-primary` | `#f56907` | Focus ring and border color |
+| `--shadow-primary-input` | `inset 0 1px 1px …` | Focus box-shadow |
+
+> Overriding any variable in `:root` or a parent selector propagates automatically to all `Input` instances inside that scope.
+
+## Usage
+
+```jsx
+import { useState } from 'react';
+import { Input, InputLabel } from 'thecore-auth';
+
+function LoginFields() {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+
+  return (
+    <form onSubmit={(e) => e.preventDefault()}>
+      <div className="flex flex-col gap-1 mb-4">
+        <InputLabel label="Email" labelId="email" />
+        <Input
+          inputType="email"
+          inputId="email"
+          inputName="email"
+          inputPlaceholder="you@example.com"
+          inputValue={email}
+          inputChange={(e) => setEmail(e.target.value)}
+        />
+      </div>
+
+      <div className="flex flex-col gap-1">
+        <InputLabel label="Password" labelId="password" />
+        <Input
+          inputType="password"
+          inputId="password"
+          inputName="password"
+          inputPlaceholder="••••••••"
+          inputValue={password}
+          inputChange={(e) => setPassword(e.target.value)}
+          inputStyle="font-mono tracking-widest"
+        />
+      </div>
+    </form>
+  );
+}
+```
+
+## Notes
+
+- `inputType` is validated against `['text', 'email', 'password', 'search', 'tel', 'url']`. Any unsupported value silently falls back to `'text'`.
+- `inputRequired` defaults to `true` — pass `inputRequired={false}` explicitly for optional fields.
+- Use `overrideStyle` to completely replace the default class string when design tokens do not apply.
+- Use `inputStyle` to append classes without losing the default token-based styling.

--- a/docs/components/InputDate.md
+++ b/docs/components/InputDate.md
@@ -1,0 +1,96 @@
+# InputDate
+
+> **Versione italiana:** [docs/it/components/InputDate.md](../it/components/InputDate.md) | **Versión española:** [docs/es/components/InputDate.md](../es/components/InputDate.md)
+
+## Overview
+
+A labelled `<input type="date">` wrapped in a flex column container. It applies the project's CSS-variable-driven design tokens (background, border, focus ring, padding, radius) and supports a disabled state with dedicated opacity/cursor styles. An optional `children` slot allows appending validation messages or helper text below the input.
+
+## Import
+
+```js
+import { InputDate } from 'thecore-auth';
+```
+
+## Props
+
+| Name | Type | Default | Required | Description |
+|---|---|---|---|---|
+| `id` | `string` | — | Yes | `id` attribute of the input; also used as the label's `htmlFor`. |
+| `name` | `string` | — | No | `name` attribute for form submission. |
+| `value` | `string` | `''` | No | Controlled value in `YYYY-MM-DD` format. |
+| `onChange` | `(e: ChangeEvent) => void` | — | Yes | `onChange` handler. |
+| `disabled` | `boolean` | — | No | Disables the input; applies muted styling automatically. |
+| `required` | `boolean` | — | No | Maps to the native `required` attribute. |
+| `title` | `string` | — | No | Label text rendered above the input. |
+| `containerStyle` | `string` | `'flex flex-col gap-1 mx-auto w-full'` | No | Class string for the wrapping `<div>`. |
+| `labelStyle` | `string` | See below | No | Class string for the `<label>`. |
+| `inputStyle` | `string` | See below | No | Class string for the `<input>`. |
+| `children` | `ReactNode` | — | No | Content rendered below the input (e.g., validation error messages). |
+
+**Default `labelStyle`:** `mb-1 text-input-label font-medium text-color-label`
+
+**Default `inputStyle`:** `bg-input-bg border border-input-border rounded-lg text-input-text placeholder:text-input-placeholder rounded-input focus:ring focus:ring-primary focus:border-primary focus:outline-none focus:shadow-[var(--shadow-primary-input)] block w-full h-[43px] p-input disabled:bg-gray-100 disabled:text-gray-400 disabled:cursor-not-allowed disabled:opacity-60`
+
+## CSS Variables
+
+| Variable | Default | Effect |
+|---|---|---|
+| `--color-input-bg` | `#f9fafb` | Input background (`bg-input-bg`) |
+| `--color-input-border` | `#d1d5db` | Border color (`border-input-border`) |
+| `--color-input-text` | `#111827` | Text color (`text-input-text`) |
+| `--text-input-label` | `14px` | Label font size (`text-input-label`) |
+| `--color-color-label` | `#111827` | Label text color (`text-color-label`) |
+| `--input-radius` | `8px` | Border radius (`rounded-input`) |
+| `--padding-input` | `10px` | Internal padding (`p-input`) |
+| `--color-primary` | `#f56907` | Focus ring and border color |
+| `--shadow-primary-input` | `inset 0 1px 1px …` | Focus box-shadow |
+
+## Usage
+
+```jsx
+import { useState } from 'react';
+import { InputDate } from 'thecore-auth';
+
+function BookingForm() {
+  const [checkIn, setCheckIn] = useState('');
+  const [error, setError] = useState('');
+
+  const handleChange = (e) => {
+    setCheckIn(e.target.value);
+    setError('');
+  };
+
+  const validate = () => {
+    if (!checkIn) setError('Check-in date is required.');
+  };
+
+  return (
+    <form onSubmit={(e) => { e.preventDefault(); validate(); }}>
+      <InputDate
+        id="check-in"
+        name="checkIn"
+        title="Check-in date"
+        value={checkIn}
+        onChange={handleChange}
+        required
+      >
+        {error && (
+          <p className="text-red-500 text-xs mt-1">{error}</p>
+        )}
+      </InputDate>
+
+      <button type="submit" className="mt-4 px-4 py-2 bg-primary text-white rounded">
+        Book
+      </button>
+    </form>
+  );
+}
+```
+
+## Notes
+
+- `value` defaults to an empty string `""` when `undefined` is passed, preventing React's uncontrolled-to-controlled warning.
+- The disabled state applies `bg-gray-100`, `text-gray-400`, `cursor-not-allowed`, and `opacity-60` through the default `inputStyle` — no extra prop is needed.
+- Override `containerStyle`, `labelStyle`, or `inputStyle` individually; all three default strings remain available for copy-paste as a baseline.
+- `children` is rendered inside the end-date `InputDate` by `InputStartEndDate` to display date-range validation errors — see the `InputStartEndDate` reference for the composed pattern.

--- a/docs/components/InputLabel.md
+++ b/docs/components/InputLabel.md
@@ -1,0 +1,68 @@
+# InputLabel
+
+> **Versione italiana:** [docs/it/components/InputLabel.md](../it/components/InputLabel.md) | **Versión española:** [docs/es/components/InputLabel.md](../es/components/InputLabel.md)
+
+## Overview
+
+A thin wrapper around the HTML `<label>` element. It applies design-token-driven typography and visibility, and links to its paired input via `htmlFor`. The default display (`block` or `none`) is controlled by the `--label-display` CSS variable, making it easy to hide labels globally in compact layouts without removing them from the DOM (accessibility is preserved).
+
+## Import
+
+```js
+import { InputLabel } from 'thecore-auth';
+```
+
+## Props
+
+| Name | Type | Default | Required | Description |
+|---|---|---|---|---|
+| `label` | `string` | — | Yes | Text content of the label. |
+| `labelId` | `string` | — | Yes | Value of the `htmlFor` attribute; must match the paired input's `id`. |
+| `labelStyle` | `string` | `''` | No | Extra Tailwind classes appended to the default class string. |
+| `overrideStyle` | `string` | — | No | Replaces the entire default class string when provided. |
+
+## CSS Variables
+
+| Variable | Default | Effect |
+|---|---|---|
+| `--label-display` | `block` | Controls label visibility via `.show-label { display: var(--label-display) }` |
+| `--text-input-label` | `14px` | Font size (`text-input-label`) |
+| `--color-color-label` | `#111827` | Text color (`text-color-label`) |
+
+> Set `--label-display: none` on a parent scope to hide all labels while keeping them in the DOM for screen readers.
+
+## Usage
+
+```jsx
+import { Input, InputLabel } from 'thecore-auth';
+import { useState } from 'react';
+
+function SearchField() {
+  const [query, setQuery] = useState('');
+
+  return (
+    <div className="flex flex-col gap-1 w-full max-w-sm">
+      <InputLabel
+        label="Search"
+        labelId="global-search"
+        labelStyle="text-slate-600"
+      />
+      <Input
+        inputType="search"
+        inputId="global-search"
+        inputName="q"
+        inputPlaceholder="Type to search…"
+        inputValue={query}
+        inputChange={(e) => setQuery(e.target.value)}
+        inputRequired={false}
+      />
+    </div>
+  );
+}
+```
+
+## Notes
+
+- Always pair `labelId` with the corresponding input's `id` to satisfy accessibility requirements.
+- `overrideStyle` removes the `.show-label` class, which means `--label-display` no longer controls visibility — use `labelStyle` to extend instead.
+- The `.show-label` utility class is defined in `src/css/index.css` and reads `--label-display` from the theme.

--- a/docs/components/InputStartEndDate.md
+++ b/docs/components/InputStartEndDate.md
@@ -1,0 +1,94 @@
+# InputStartEndDate
+
+> **Versione italiana:** [docs/it/components/InputStartEndDate.md](../it/components/InputStartEndDate.md) | **Versión española:** [docs/es/components/InputStartEndDate.md](../es/components/InputStartEndDate.md)
+
+## Overview
+
+A date-range picker that composes two `InputDate` components side by side. The end-date field can be hidden with `endDateShow={false}`, and a validation error string (`dateError`) is rendered below the end-date input. Both fields share the same `onChange` handler, `disabled`, `required`, and `labelStyle` props, while each field can receive its own container and input style overrides.
+
+## Import
+
+```js
+import { InputStartEndDate } from 'thecore-auth';
+```
+
+## Props
+
+| Name | Type | Default | Required | Description |
+|---|---|---|---|---|
+| `startId` | `string` | — | Yes | `id` of the start-date input. |
+| `endId` | `string` | — | No | `id` of the end-date input. |
+| `startName` | `string` | — | No | `name` of the start-date input for form submission. |
+| `endName` | `string` | — | No | `name` of the end-date input for form submission. |
+| `startValue` | `string` | — | No | Controlled value of the start date (`YYYY-MM-DD`). |
+| `endValue` | `string` | — | No | Controlled value of the end date (`YYYY-MM-DD`). |
+| `onChange` | `(e: ChangeEvent) => void` | — | Yes | Shared `onChange` handler for both fields. |
+| `disabled` | `boolean` | — | No | Disables both fields. |
+| `required` | `boolean` | — | No | Makes both fields required. |
+| `dateError` | `string` | — | No | Validation message shown below the end-date field in red. |
+| `startTitle` | `string` | — | No | Label text for the start-date field. |
+| `endTitle` | `string` | — | No | Label text for the end-date field. |
+| `containerStyle` | `string` | `'flex gap-4 mx-auto w-full mb-4'` | No | Class string for the outer wrapper. |
+| `startContainerStyle` | `string` | — | No | `containerStyle` forwarded to the start `InputDate`. |
+| `endContainerStyle` | `string` | — | No | `containerStyle` forwarded to the end `InputDate`. |
+| `startStyle` | `string` | — | No | `inputStyle` forwarded to the start `InputDate`. |
+| `endStyle` | `string` | — | No | `inputStyle` forwarded to the end `InputDate`. |
+| `labelStyle` | `string` | — | No | `labelStyle` forwarded to both `InputDate` components. |
+| `endDateShow` | `boolean` | `true` | No | Set to `false` to render only the start-date field. |
+| `children` | `ReactNode` | — | No | Extra content appended after both date fields inside the wrapper. |
+
+## CSS Variables
+
+`InputStartEndDate` delegates all rendering to `InputDate` — see [InputDate CSS Variables](./InputDate.md#css-variables) for the full list.
+
+## Usage
+
+```jsx
+import { useState } from 'react';
+import { InputStartEndDate } from 'thecore-auth';
+
+function VacationPicker() {
+  const [dates, setDates] = useState({ start: '', end: '' });
+  const [error, setError] = useState('');
+
+  const handleChange = (e) => {
+    const { name, value } = e.target;
+    setDates((prev) => {
+      const next = { ...prev, [name]: value };
+
+      // Validate: end must not precede start
+      if (next.start && next.end && next.end < next.start) {
+        setError('End date must be after start date.');
+      } else {
+        setError('');
+      }
+
+      return next;
+    });
+  };
+
+  return (
+    <InputStartEndDate
+      startId="vacation-start"
+      endId="vacation-end"
+      startName="start"
+      endName="end"
+      startTitle="From"
+      endTitle="To"
+      startValue={dates.start}
+      endValue={dates.end}
+      onChange={handleChange}
+      dateError={error}
+      required
+    />
+  );
+}
+```
+
+## Notes
+
+- `onChange` receives a standard DOM `ChangeEvent`; use `e.target.name` to distinguish between the two fields (pair with `startName` / `endName`).
+- `dateError` is rendered inside the end-date `InputDate`'s `children` slot as a `<p className="text-red-500 text-[13px] mt-1">`. Provide `null` or omit the prop to suppress it.
+- Set `endDateShow={false}` when you need a single-date picker but want to keep the same field-sizing and layout as the range variant.
+- `children` is appended after both date fields in the outer wrapper — use it for actions (e.g., a "Clear" button) or supplementary messages.
+- Both `InputDate` instances share the same `onChange`, `disabled`, `required`, and `labelStyle` — they cannot be configured independently for these props.

--- a/docs/components/MultiSelect.md
+++ b/docs/components/MultiSelect.md
@@ -1,0 +1,126 @@
+# MultiSelect
+
+> **Versione italiana:** [docs/it/components/MultiSelect.md](../it/components/MultiSelect.md) | **Versión española:** [docs/es/components/MultiSelect.md](../es/components/MultiSelect.md)
+
+## Overview
+
+A searchable, multi-value dropdown. Selected items appear as removable tags inside the trigger. Clicking the trigger opens a dropdown with a search input and a scrollable list. Clicking an item toggles its selection; clicking outside closes the dropdown (`useClickOutside`).
+
+Supports two selection modes:
+- **Direct mode** — `updateFilter` receives the new `Array` of selected items directly.
+- **Filter-key mode** — pass a `type` string and `updateFilter` receives a state-updater function that patches a keyed filter object.
+
+## Import
+
+```js
+import { MultiSelect } from 'thecore-auth';
+```
+
+## Props
+
+| Name | Type | Default | Required | Description |
+|---|---|---|---|---|
+| `items` | `object[]` | — | Yes | Full list of options to display. Each item must have a unique `idKey` property. |
+| `value` | `object[]` | `[]` | No | Currently selected items. Must be a subset of `items`. |
+| `label` | `string` | — | No | Header label rendered above the trigger. |
+| `placeholder` | `string` | — | No | Placeholder text shown inside the trigger when nothing is selected. |
+| `displayKey` | `string \| string[]` | — | No | Key(s) of each item used to build the display string. Accepts a single key or an array of keys joined by a space. Falls back to `code`, `name`, `label`, or `idKey` when omitted. |
+| `valueKey` | `string` | — | No | Key used to render the tag label (overrides `displayKey` inside tags). |
+| `idKey` | `string` | `'id'` | No | Key used as the unique identifier for each item. |
+| `type` | `string` | — | No | When provided, activates filter-key mode: `updateFilter` is called with a state-updater that patches `prev[type]`. |
+| `updateFilter` | `Function` | — | Yes | Selection change handler. In direct mode receives the new `object[]`; in filter-key mode receives a state-updater `(prev) => next`. |
+| `searchPlaceholder` | `string` | `'Cerca...'` | No | Placeholder for the in-dropdown search input. |
+| `noResultsText` | `string` | `'Nessun risultato'` | No | Text shown when the search query matches no items. |
+| `classNames` | `object` | `{}` | No | Partial class name overrides merged with the defaults. See **Class Name Keys** below. |
+
+### Class Name Keys
+
+All keys are optional. Unspecified keys fall back to the defaults listed in the source.
+
+| Key | Targets |
+|---|---|
+| `container` | Outermost `<div>` |
+| `label` | Header label `<div>` |
+| `trigger` | Clickable trigger `<div>` |
+| `placeholder` | Placeholder `<span>` |
+| `tag` | Each selected-item tag `<span>` |
+| `tagButton` | Remove button inside each tag |
+| `chevron` | Chevron icon |
+| `dropdown` | Dropdown `<div>` |
+| `searchInput` | Search `<input>` |
+| `list` | `<ul>` |
+| `listItem` | Each `<li>` |
+| `listItemSelected` | Added to `<li>` when the item is selected |
+| `noResults` | "No results" `<li>` |
+
+## CSS Variables
+
+| Variable | Default | Effect |
+|---|---|---|
+| `--color-input-bg` | `#f9fafb` | Dropdown background (`bg-input-bg`) |
+| `--color-input-border` | `#d1d5db` | Dropdown border (`border-input-border`) |
+| `--text-input-label` | `14px` | Label font size (`text-input-label`) |
+| `--color-color-label` | `#111827` | Label text color (`text-color-label`) |
+
+## Usage
+
+```jsx
+import { useState } from 'react';
+import { MultiSelect } from 'thecore-auth';
+
+const TAGS = [
+  { id: 1, name: 'React' },
+  { id: 2, name: 'TypeScript' },
+  { id: 3, name: 'Tailwind' },
+  { id: 4, name: 'Vite' },
+];
+
+function TechStackPicker() {
+  const [selected, setSelected] = useState([]);
+
+  return (
+    <div className="w-80">
+      <MultiSelect
+        label="Tech stack"
+        items={TAGS}
+        value={selected}
+        placeholder="Select technologies…"
+        displayKey="name"
+        idKey="id"
+        updateFilter={setSelected}
+        searchPlaceholder="Search…"
+        noResultsText="No technologies found"
+      />
+      <p className="text-xs text-slate-400">
+        Selected: {selected.map((t) => t.name).join(', ') || 'none'}
+      </p>
+    </div>
+  );
+}
+```
+
+### Filter-key mode
+
+```jsx
+// Manage a composite filter object with multiple MultiSelect instances
+const [filters, setFilters] = useState({ tags: [], categories: [] });
+
+<MultiSelect
+  items={TAGS}
+  value={filters.tags}
+  type="tags"
+  updateFilter={setFilters}
+  displayKey="name"
+  idKey="id"
+  placeholder="Filter by tag…"
+/>
+```
+
+## Notes
+
+- The search input is auto-focused when the dropdown opens.
+- Clicking outside the component closes the dropdown via `useClickOutside` from `src/hooks/ui/useClickOutside`.
+- The chevron icon rotates 180° when the dropdown is open (`rotate-180` Tailwind class).
+- `EMPTY_ARRAY` is a module-level constant used as the default for `value` to preserve referential stability and avoid unnecessary re-renders.
+- `displayKey` as an array merges multiple fields (`['firstName', 'lastName']` → `"John Doe"`); falsy field values are filtered out before joining.
+- Default `searchPlaceholder` and `noResultsText` are in Italian — override them for other locales.

--- a/docs/components/SingleSelect.md
+++ b/docs/components/SingleSelect.md
@@ -1,0 +1,57 @@
+# SingleSelect
+
+> **Versione italiana:** [docs/it/components/SingleSelect.md](../it/components/SingleSelect.md) | **Versión española:** [docs/es/components/SingleSelect.md](../es/components/SingleSelect.md)
+
+## Overview
+
+A fully controlled single-value selector rendered as a vertical stack of buttons. Each option is displayed as an uppercase pill; the active option is highlighted in blue. Intended for small, enumerable option sets where all choices should be visible at a glance (e.g., filter panels, configuration pickers).
+
+## Import
+
+```js
+import { SingleSelect } from 'thecore-auth';
+```
+
+## Props
+
+| Name | Type | Default | Required | Description |
+|---|---|---|---|---|
+| `options` | `string[]` | `[]` | No | Array of string values to render as selectable buttons. |
+| `value` | `string` | — | Yes | The currently selected option. Must match one of the strings in `options`. |
+| `onChange` | `(selected: string) => void` | — | Yes | Called with the clicked option string when the user selects a new value. |
+
+## CSS Variables
+
+`SingleSelect` does not use CSS custom properties from `src/css/index.css`. Active and inactive styles are hardcoded Tailwind classes (`bg-blue-500`, `bg-white`, `border-blue-500`, `border-slate-100`).
+
+## Usage
+
+```jsx
+import { useState } from 'react';
+import { SingleSelect } from 'thecore-auth';
+
+const ROLES = ['Admin', 'Editor', 'Viewer'];
+
+function RolePicker() {
+  const [role, setRole] = useState('Viewer');
+
+  return (
+    <div className="w-48">
+      <p className="mb-2 text-sm font-medium text-slate-600">Select role</p>
+      <SingleSelect
+        options={ROLES}
+        value={role}
+        onChange={setRole}
+      />
+      <p className="mt-3 text-xs text-slate-400">Selected: {role}</p>
+    </div>
+  );
+}
+```
+
+## Notes
+
+- All buttons render with `type="button"` to avoid accidental form submission.
+- The active state check is a strict equality comparison (`value === option`) — values must be unique within `options`.
+- Labels are rendered in uppercase via `uppercase tracking-tighter` — the display is always the raw string from `options`; there is no separate `label`/`value` mapping. If you need to separate display labels from internal values, derive `options` from a mapped array and convert on `onChange`.
+- No scroll container is applied — for large option sets consider `MultiSelect` instead.

--- a/docs/components/SwitchRadio.md
+++ b/docs/components/SwitchRadio.md
@@ -1,0 +1,79 @@
+# SwitchRadio
+
+> **Versione italiana:** [docs/it/components/SwitchRadio.md](../it/components/SwitchRadio.md) | **Versión española:** [docs/es/components/SwitchRadio.md](../es/components/SwitchRadio.md)
+
+## Overview
+
+A toggle switch rendered as an accessible `<button>`. Supports both **controlled** and **uncontrolled** modes:
+
+- **Controlled** — pass a `value` prop and manage state externally.
+- **Uncontrolled** — omit `value`; the component holds state internally, seeded by `defaultValue`.
+
+In both modes the `onChange` callback is fired on every toggle.
+
+## Import
+
+```js
+import { SwitchRadio } from 'thecore-auth';
+```
+
+## Props
+
+| Name | Type | Default | Required | Description |
+|---|---|---|---|---|
+| `value` | `boolean` | — | No | Controlled on/off state. When provided the component is in controlled mode. |
+| `defaultValue` | `boolean` | `false` | No | Initial state for uncontrolled mode. Re-seeded whenever it changes (only in uncontrolled mode). |
+| `onChange` | `(next: boolean) => void` | — | No | Called with the new boolean value after every toggle, in both controlled and uncontrolled modes. |
+
+## CSS Variables
+
+`SwitchRadio` does not use CSS custom properties from `src/css/index.css`. Colors and sizes are hardcoded Tailwind classes (`bg-blue-500`, `bg-gray-300`, `w-14`, `h-6`).
+
+## Usage
+
+### Controlled
+
+```jsx
+import { useState } from 'react';
+import { SwitchRadio } from 'thecore-auth';
+
+function NotificationSettings() {
+  const [enabled, setEnabled] = useState(false);
+
+  return (
+    <div className="flex items-center gap-3">
+      <span className="text-sm font-medium">Email notifications</span>
+      <SwitchRadio
+        value={enabled}
+        onChange={setEnabled}
+      />
+      <span className="text-sm text-slate-500">{enabled ? 'On' : 'Off'}</span>
+    </div>
+  );
+}
+```
+
+### Uncontrolled
+
+```jsx
+import { SwitchRadio } from 'thecore-auth';
+
+function FeatureFlag() {
+  return (
+    <div className="flex items-center gap-3">
+      <span className="text-sm font-medium">Beta features</span>
+      <SwitchRadio
+        defaultValue={true}
+        onChange={(next) => console.log('beta:', next)}
+      />
+    </div>
+  );
+}
+```
+
+## Notes
+
+- The button renders with `aria-pressed` reflecting the current on/off state, ensuring screen reader compatibility.
+- In uncontrolled mode, if the parent changes `defaultValue` the internal state re-syncs (via `useEffect`). This is intentional for cases where the default is loaded asynchronously (e.g., from an API).
+- In controlled mode the parent is solely responsible for updating `value`; the component itself never mutates the prop.
+- The component does not expose a `name`/`value` pair compatible with native form serialization — wire `onChange` to a hidden input if form submission is required.

--- a/docs/es/components/FileDropzone.md
+++ b/docs/es/components/FileDropzone.md
@@ -1,0 +1,73 @@
+# FileDropzone
+
+> **English:** [docs/components/FileDropzone.md](../../components/FileDropzone.md) | **Versione italiana:** [docs/it/components/FileDropzone.md](../it/components/FileDropzone.md)
+
+## Overview
+
+Una zona de carga de archivos con arrastrar y soltar. Gestiona los eventos `dragenter`, `dragover`, `dragleave` y `drop`, y reenvía los archivos seleccionados — ya sea arrastrados o elegidos mediante el diálogo nativo de archivos — como un `Array<File>` al callback `onFilesSelect`. Aparece una superposición de borde animado mientras hay un arrastre en progreso. Todas las regiones visuales son personalizables mediante props de estilo dedicadas.
+
+## Import
+
+```js
+import { FileDropzone } from 'thecore-auth';
+```
+
+## Props
+
+| Name | Type | Default | Required | Description |
+|---|---|---|---|---|
+| `onFilesSelect` | `(files: File[]) => void` | — | Yes | Se llama con un `Array<File>` cada vez que el usuario suelta o selecciona archivos. |
+| `id` | `string` | `'dropzone-file'` | No | Atributo `id` del `<input type="file">` oculto. |
+| `containerStyle` | `string` | `'flex items-center justify-center w-full relative h-full'` | No | Cadena de clases para el `<div>` más externo. |
+| `labelStyle` | `string` | Ver abajo | No | Cadena de clases para el `<label>` que envuelve el área visible de la zona. Incluye interpolación del estado de arrastre activo por defecto. |
+| `dropzoneStyle` | `string` | `'flex flex-col items-center justify-center text-body px-6 text-center pt-5 pb-6 pointer-events-none'` | No | Cadena de clases para el bloque de contenido interno (icono + texto). |
+| `dragActiveStyle` | `string` | `'absolute w-full h-full top-0 left-0 rounded-2xl border-2 border-primary-strong/70 animate-pulse'` | No | Cadena de clases para el `<div>` de superposición renderizado cuando hay un arrastre en progreso. |
+
+**`labelStyle` predeterminado:**
+```
+flex flex-col items-center justify-center w-full h-full rounded-2xl transition-all
+duration-300 bg-slate-100/80 shadow-lg border border-slate-300 rounded-base
+cursor-pointer hover:bg-slate-200/80 hover:border-slate-500 hover:shadow-xl
+[drag-active: bg-slate-200/80 border-slate-600 shadow-xl shadow-primary-strong]
+```
+
+## CSS Variables
+
+`FileDropzone` no utiliza propiedades CSS personalizadas de `src/css/index.css`. Todo el estilo se expresa mediante clases utilitarias de Tailwind en los valores predeterminados de las props.
+
+## Usage
+
+```jsx
+import { useState } from 'react';
+import { FileDropzone } from 'thecore-auth';
+
+function UploadPanel() {
+  const [files, setFiles] = useState([]);
+
+  const handleFiles = (selected) => {
+    setFiles((prev) => [...prev, ...selected]);
+  };
+
+  return (
+    <div className="h-64 w-full max-w-lg mx-auto">
+      <FileDropzone onFilesSelect={handleFiles} />
+
+      {files.length > 0 && (
+        <ul className="mt-4 text-sm text-slate-600 space-y-1">
+          {files.map((f, i) => (
+            <li key={i}>{f.name} — {(f.size / 1024).toFixed(1)} KB</li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+```
+
+## Notes
+
+- El `<input type="file">` oculto tiene el atributo `multiple`, por lo que los usuarios siempre pueden seleccionar más de un archivo independientemente de la ruta de arrastrar y soltar.
+- Los eventos de arrastre (`dragenter`, `dragover`, `dragleave`) se gestionan con `useCallback` para evitar recrear los manejadores en cada renderizado.
+- La superposición de arrastre activo intercepta los eventos de puntero durante un arrastre para evitar que el cursor salga de los límites de la zona; se elimina inmediatamente en `drop` o `dragleave`.
+- El icono de carga (`SlCloudUpload`) se importa desde `react-icons/sl` — asegúrate de que este paquete esté disponible en el proyecto consumidor.
+- El texto de la interfaz dentro del componente está actualmente en italiano ("Clicca per caricare…"); sobrescribe `dropzoneStyle` o bifurca el componente si necesitas una configuración regional diferente.

--- a/docs/es/components/Input.md
+++ b/docs/es/components/Input.md
@@ -1,0 +1,92 @@
+# Input
+
+> **English:** [docs/components/Input.md](../../components/Input.md) | **Versione italiana:** [docs/it/components/Input.md](../it/components/Input.md)
+
+## Overview
+
+Un input de texto controlado que envuelve el elemento nativo `<input>`. Restringe `type` a una lista de valores permitidos seguros y aplica los tokens de diseño basados en variables CSS del proyecto por defecto. Cualquier clase puede ser reemplazada con `overrideStyle` o extendida con `inputStyle`.
+
+## Import
+
+```js
+import { Input } from 'thecore-auth';
+```
+
+## Props
+
+| Name | Type | Default | Required | Description |
+|---|---|---|---|---|
+| `inputType` | `'text' \| 'email' \| 'password' \| 'search' \| 'tel' \| 'url'` | `'text'` | No | Tipo nativo del input. Vuelve a `'text'` si se proporciona un valor no válido. |
+| `inputId` | `string` | — | No | Atributo `id`; emparejar con un `InputLabel` para accesibilidad. |
+| `inputName` | `string` | — | No | Atributo `name` para el envío del formulario. |
+| `inputValue` | `string` | — | Yes | Valor controlado. |
+| `inputChange` | `(e: ChangeEvent) => void` | — | Yes | Manejador de `onChange`. |
+| `inputPlaceholder` | `string` | — | No | Texto de marcador de posición. |
+| `inputRequired` | `boolean` | `true` | No | Se corresponde con el atributo nativo `required`. |
+| `autoFocus` | `boolean` | — | No | Enfoca automáticamente el campo al montar. |
+| `inputStyle` | `string` | `''` | No | Clases Tailwind adicionales que se añaden a la cadena de clases predeterminada. |
+| `overrideStyle` | `string` | — | No | Reemplaza toda la cadena de clases predeterminada cuando se proporciona. |
+| `disabled` | `boolean` | — | No | Deshabilita el input. |
+
+## CSS Variables
+
+| Variable | Default | Effect |
+|---|---|---|
+| `--color-input-bg` | `#f9fafb` | Fondo del input (`bg-input-bg`) |
+| `--color-input-border` | `#d1d5db` | Color del borde (`border-input-border`) |
+| `--color-input-text` | `#111827` | Color del texto (`text-input-text`) |
+| `--text-input-placeholder` | `14px` | Tamaño de fuente del marcador de posición (`text-input-placeholder`) |
+| `--input-radius` | `8px` | Radio del borde (`.input-rounded`) |
+| `--padding-input` | `10px` | Relleno interno (`p-input`) |
+| `--color-primary` | `#f56907` | Color del anillo de enfoque y del borde |
+| `--shadow-primary-input` | `inset 0 1px 1px …` | Box-shadow al enfocar |
+
+> Sobrescribir cualquier variable en `:root` o en un selector padre se propaga automáticamente a todas las instancias de `Input` dentro de ese ámbito.
+
+## Usage
+
+```jsx
+import { useState } from 'react';
+import { Input, InputLabel } from 'thecore-auth';
+
+function LoginFields() {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+
+  return (
+    <form onSubmit={(e) => e.preventDefault()}>
+      <div className="flex flex-col gap-1 mb-4">
+        <InputLabel label="Email" labelId="email" />
+        <Input
+          inputType="email"
+          inputId="email"
+          inputName="email"
+          inputPlaceholder="you@example.com"
+          inputValue={email}
+          inputChange={(e) => setEmail(e.target.value)}
+        />
+      </div>
+
+      <div className="flex flex-col gap-1">
+        <InputLabel label="Password" labelId="password" />
+        <Input
+          inputType="password"
+          inputId="password"
+          inputName="password"
+          inputPlaceholder="••••••••"
+          inputValue={password}
+          inputChange={(e) => setPassword(e.target.value)}
+          inputStyle="font-mono tracking-widest"
+        />
+      </div>
+    </form>
+  );
+}
+```
+
+## Notes
+
+- `inputType` se valida contra `['text', 'email', 'password', 'search', 'tel', 'url']`. Cualquier valor no soportado regresa silenciosamente a `'text'`.
+- `inputRequired` tiene como valor predeterminado `true` — pasa `inputRequired={false}` explícitamente para campos opcionales.
+- Usa `overrideStyle` para reemplazar completamente la cadena de clases predeterminada cuando los tokens de diseño no aplican.
+- Usa `inputStyle` para añadir clases sin perder el estilo predeterminado basado en tokens.

--- a/docs/es/components/InputDate.md
+++ b/docs/es/components/InputDate.md
@@ -1,0 +1,96 @@
+# InputDate
+
+> **English:** [docs/components/InputDate.md](../../components/InputDate.md) | **Versione italiana:** [docs/it/components/InputDate.md](../it/components/InputDate.md)
+
+## Overview
+
+Un `<input type="date">` con etiqueta envuelto en un contenedor flex en columna. Aplica los tokens de diseño basados en variables CSS del proyecto (fondo, borde, anillo de enfoque, relleno, radio) y soporta un estado deshabilitado con estilos de opacidad y cursor dedicados. Un slot `children` opcional permite añadir mensajes de validación o texto de ayuda debajo del input.
+
+## Import
+
+```js
+import { InputDate } from 'thecore-auth';
+```
+
+## Props
+
+| Name | Type | Default | Required | Description |
+|---|---|---|---|---|
+| `id` | `string` | — | Yes | Atributo `id` del input; también se usa como `htmlFor` de la etiqueta. |
+| `name` | `string` | — | No | Atributo `name` para el envío del formulario. |
+| `value` | `string` | `''` | No | Valor controlado en formato `YYYY-MM-DD`. |
+| `onChange` | `(e: ChangeEvent) => void` | — | Yes | Manejador de `onChange`. |
+| `disabled` | `boolean` | — | No | Deshabilita el input; aplica estilos atenuados automáticamente. |
+| `required` | `boolean` | — | No | Se corresponde con el atributo nativo `required`. |
+| `title` | `string` | — | No | Texto de la etiqueta renderizado encima del input. |
+| `containerStyle` | `string` | `'flex flex-col gap-1 mx-auto w-full'` | No | Cadena de clases para el `<div>` envolvente. |
+| `labelStyle` | `string` | Ver abajo | No | Cadena de clases para el `<label>`. |
+| `inputStyle` | `string` | Ver abajo | No | Cadena de clases para el `<input>`. |
+| `children` | `ReactNode` | — | No | Contenido renderizado debajo del input (p. ej., mensajes de error de validación). |
+
+**`labelStyle` predeterminado:** `mb-1 text-input-label font-medium text-color-label`
+
+**`inputStyle` predeterminado:** `bg-input-bg border border-input-border rounded-lg text-input-text placeholder:text-input-placeholder rounded-input focus:ring focus:ring-primary focus:border-primary focus:outline-none focus:shadow-[var(--shadow-primary-input)] block w-full h-[43px] p-input disabled:bg-gray-100 disabled:text-gray-400 disabled:cursor-not-allowed disabled:opacity-60`
+
+## CSS Variables
+
+| Variable | Default | Effect |
+|---|---|---|
+| `--color-input-bg` | `#f9fafb` | Fondo del input (`bg-input-bg`) |
+| `--color-input-border` | `#d1d5db` | Color del borde (`border-input-border`) |
+| `--color-input-text` | `#111827` | Color del texto (`text-input-text`) |
+| `--text-input-label` | `14px` | Tamaño de fuente de la etiqueta (`text-input-label`) |
+| `--color-color-label` | `#111827` | Color del texto de la etiqueta (`text-color-label`) |
+| `--input-radius` | `8px` | Radio del borde (`rounded-input`) |
+| `--padding-input` | `10px` | Relleno interno (`p-input`) |
+| `--color-primary` | `#f56907` | Color del anillo de enfoque y del borde |
+| `--shadow-primary-input` | `inset 0 1px 1px …` | Box-shadow al enfocar |
+
+## Usage
+
+```jsx
+import { useState } from 'react';
+import { InputDate } from 'thecore-auth';
+
+function BookingForm() {
+  const [checkIn, setCheckIn] = useState('');
+  const [error, setError] = useState('');
+
+  const handleChange = (e) => {
+    setCheckIn(e.target.value);
+    setError('');
+  };
+
+  const validate = () => {
+    if (!checkIn) setError('Check-in date is required.');
+  };
+
+  return (
+    <form onSubmit={(e) => { e.preventDefault(); validate(); }}>
+      <InputDate
+        id="check-in"
+        name="checkIn"
+        title="Check-in date"
+        value={checkIn}
+        onChange={handleChange}
+        required
+      >
+        {error && (
+          <p className="text-red-500 text-xs mt-1">{error}</p>
+        )}
+      </InputDate>
+
+      <button type="submit" className="mt-4 px-4 py-2 bg-primary text-white rounded">
+        Book
+      </button>
+    </form>
+  );
+}
+```
+
+## Notes
+
+- `value` tiene como valor predeterminado una cadena vacía `""` cuando se pasa `undefined`, evitando la advertencia de React sobre pasar de componente no controlado a controlado.
+- El estado deshabilitado aplica `bg-gray-100`, `text-gray-400`, `cursor-not-allowed` y `opacity-60` a través del `inputStyle` predeterminado — no se necesita ninguna prop adicional.
+- Sobrescribe `containerStyle`, `labelStyle` o `inputStyle` individualmente; las tres cadenas predeterminadas siguen disponibles como punto de partida para copiar y pegar.
+- `children` se renderiza dentro del slot `children` del `InputDate` de fecha de fin por `InputStartEndDate` para mostrar errores de validación de rango de fechas — consulta la referencia de `InputStartEndDate` para ver el patrón compuesto.

--- a/docs/es/components/InputLabel.md
+++ b/docs/es/components/InputLabel.md
@@ -1,0 +1,68 @@
+# InputLabel
+
+> **English:** [docs/components/InputLabel.md](../../components/InputLabel.md) | **Versione italiana:** [docs/it/components/InputLabel.md](../it/components/InputLabel.md)
+
+## Overview
+
+Un envoltorio delgado alrededor del elemento HTML `<label>`. Aplica tipografía y visibilidad basadas en tokens de diseño, y se vincula al input emparejado mediante `htmlFor`. La visualización predeterminada (`block` o `none`) está controlada por la variable CSS `--label-display`, lo que facilita ocultar etiquetas globalmente en diseños compactos sin eliminarlas del DOM (preservando la accesibilidad).
+
+## Import
+
+```js
+import { InputLabel } from 'thecore-auth';
+```
+
+## Props
+
+| Name | Type | Default | Required | Description |
+|---|---|---|---|---|
+| `label` | `string` | — | Yes | Contenido de texto de la etiqueta. |
+| `labelId` | `string` | — | Yes | Valor del atributo `htmlFor`; debe coincidir con el `id` del input emparejado. |
+| `labelStyle` | `string` | `''` | No | Clases Tailwind adicionales que se añaden a la cadena de clases predeterminada. |
+| `overrideStyle` | `string` | — | No | Reemplaza toda la cadena de clases predeterminada cuando se proporciona. |
+
+## CSS Variables
+
+| Variable | Default | Effect |
+|---|---|---|
+| `--label-display` | `block` | Controla la visibilidad de la etiqueta mediante `.show-label { display: var(--label-display) }` |
+| `--text-input-label` | `14px` | Tamaño de fuente (`text-input-label`) |
+| `--color-color-label` | `#111827` | Color del texto (`text-color-label`) |
+
+> Establece `--label-display: none` en un ámbito padre para ocultar todas las etiquetas manteniendo su presencia en el DOM para lectores de pantalla.
+
+## Usage
+
+```jsx
+import { Input, InputLabel } from 'thecore-auth';
+import { useState } from 'react';
+
+function SearchField() {
+  const [query, setQuery] = useState('');
+
+  return (
+    <div className="flex flex-col gap-1 w-full max-w-sm">
+      <InputLabel
+        label="Search"
+        labelId="global-search"
+        labelStyle="text-slate-600"
+      />
+      <Input
+        inputType="search"
+        inputId="global-search"
+        inputName="q"
+        inputPlaceholder="Type to search…"
+        inputValue={query}
+        inputChange={(e) => setQuery(e.target.value)}
+        inputRequired={false}
+      />
+    </div>
+  );
+}
+```
+
+## Notes
+
+- Siempre empareja `labelId` con el `id` del input correspondiente para cumplir los requisitos de accesibilidad.
+- `overrideStyle` elimina la clase `.show-label`, lo que significa que `--label-display` ya no controla la visibilidad — usa `labelStyle` para extender en su lugar.
+- La clase utilitaria `.show-label` está definida en `src/css/index.css` y lee `--label-display` desde el tema.

--- a/docs/es/components/InputStartEndDate.md
+++ b/docs/es/components/InputStartEndDate.md
@@ -1,0 +1,94 @@
+# InputStartEndDate
+
+> **English:** [docs/components/InputStartEndDate.md](../../components/InputStartEndDate.md) | **Versione italiana:** [docs/it/components/InputStartEndDate.md](../it/components/InputStartEndDate.md)
+
+## Overview
+
+Un selector de rango de fechas que compone dos componentes `InputDate` lado a lado. El campo de fecha de fin puede ocultarse con `endDateShow={false}`, y una cadena de error de validación (`dateError`) se renderiza debajo del input de fecha de fin. Ambos campos comparten el mismo manejador `onChange`, `disabled`, `required` y `labelStyle`, mientras que cada campo puede recibir sus propios sobreescrituras de estilo de contenedor e input.
+
+## Import
+
+```js
+import { InputStartEndDate } from 'thecore-auth';
+```
+
+## Props
+
+| Name | Type | Default | Required | Description |
+|---|---|---|---|---|
+| `startId` | `string` | — | Yes | `id` del input de fecha de inicio. |
+| `endId` | `string` | — | No | `id` del input de fecha de fin. |
+| `startName` | `string` | — | No | `name` del input de fecha de inicio para el envío del formulario. |
+| `endName` | `string` | — | No | `name` del input de fecha de fin para el envío del formulario. |
+| `startValue` | `string` | — | No | Valor controlado de la fecha de inicio (`YYYY-MM-DD`). |
+| `endValue` | `string` | — | No | Valor controlado de la fecha de fin (`YYYY-MM-DD`). |
+| `onChange` | `(e: ChangeEvent) => void` | — | Yes | Manejador de `onChange` compartido para ambos campos. |
+| `disabled` | `boolean` | — | No | Deshabilita ambos campos. |
+| `required` | `boolean` | — | No | Hace que ambos campos sean obligatorios. |
+| `dateError` | `string` | — | No | Mensaje de validación mostrado debajo del campo de fecha de fin en rojo. |
+| `startTitle` | `string` | — | No | Texto de la etiqueta para el campo de fecha de inicio. |
+| `endTitle` | `string` | — | No | Texto de la etiqueta para el campo de fecha de fin. |
+| `containerStyle` | `string` | `'flex gap-4 mx-auto w-full mb-4'` | No | Cadena de clases para el contenedor exterior. |
+| `startContainerStyle` | `string` | — | No | `containerStyle` reenviado al `InputDate` de inicio. |
+| `endContainerStyle` | `string` | — | No | `containerStyle` reenviado al `InputDate` de fin. |
+| `startStyle` | `string` | — | No | `inputStyle` reenviado al `InputDate` de inicio. |
+| `endStyle` | `string` | — | No | `inputStyle` reenviado al `InputDate` de fin. |
+| `labelStyle` | `string` | — | No | `labelStyle` reenviado a ambos componentes `InputDate`. |
+| `endDateShow` | `boolean` | `true` | No | Establece `false` para renderizar únicamente el campo de fecha de inicio. |
+| `children` | `ReactNode` | — | No | Contenido adicional añadido después de ambos campos de fecha dentro del contenedor. |
+
+## CSS Variables
+
+`InputStartEndDate` delega todo el renderizado a `InputDate` — consulta las [Variables CSS de InputDate](./InputDate.md#css-variables) para la lista completa.
+
+## Usage
+
+```jsx
+import { useState } from 'react';
+import { InputStartEndDate } from 'thecore-auth';
+
+function VacationPicker() {
+  const [dates, setDates] = useState({ start: '', end: '' });
+  const [error, setError] = useState('');
+
+  const handleChange = (e) => {
+    const { name, value } = e.target;
+    setDates((prev) => {
+      const next = { ...prev, [name]: value };
+
+      // Validate: end must not precede start
+      if (next.start && next.end && next.end < next.start) {
+        setError('End date must be after start date.');
+      } else {
+        setError('');
+      }
+
+      return next;
+    });
+  };
+
+  return (
+    <InputStartEndDate
+      startId="vacation-start"
+      endId="vacation-end"
+      startName="start"
+      endName="end"
+      startTitle="From"
+      endTitle="To"
+      startValue={dates.start}
+      endValue={dates.end}
+      onChange={handleChange}
+      dateError={error}
+      required
+    />
+  );
+}
+```
+
+## Notes
+
+- `onChange` recibe un `ChangeEvent` DOM estándar; usa `e.target.name` para distinguir entre los dos campos (emparejar con `startName` / `endName`).
+- `dateError` se renderiza dentro del slot `children` del `InputDate` de fecha de fin como un `<p className="text-red-500 text-[13px] mt-1">`. Proporciona `null` u omite la prop para suprimirlo.
+- Establece `endDateShow={false}` cuando necesites un selector de fecha única pero quieras mantener el mismo tamaño de campo y diseño que la variante de rango.
+- `children` se añade después de ambos campos de fecha en el contenedor exterior — úsalo para acciones (p. ej., un botón "Limpiar") o mensajes complementarios.
+- Ambas instancias de `InputDate` comparten el mismo `onChange`, `disabled`, `required` y `labelStyle` — no pueden configurarse de forma independiente para estas props.

--- a/docs/es/components/MultiSelect.md
+++ b/docs/es/components/MultiSelect.md
@@ -1,0 +1,126 @@
+# MultiSelect
+
+> **English:** [docs/components/MultiSelect.md](../../components/MultiSelect.md) | **Versione italiana:** [docs/it/components/MultiSelect.md](../it/components/MultiSelect.md)
+
+## Overview
+
+Un desplegable con búsqueda y selección múltiple. Los elementos seleccionados aparecen como etiquetas eliminables dentro del disparador. Al hacer clic en el disparador se abre un desplegable con un input de búsqueda y una lista con scroll. Hacer clic en un elemento alterna su selección; hacer clic fuera cierra el desplegable (`useClickOutside`).
+
+Soporta dos modos de selección:
+- **Modo directo** — `updateFilter` recibe el nuevo `Array` de elementos seleccionados directamente.
+- **Modo filter-key** — pasa una cadena `type` y `updateFilter` recibe una función actualizadora de estado que parchea un objeto de filtro con clave.
+
+## Import
+
+```js
+import { MultiSelect } from 'thecore-auth';
+```
+
+## Props
+
+| Name | Type | Default | Required | Description |
+|---|---|---|---|---|
+| `items` | `object[]` | — | Yes | Lista completa de opciones a mostrar. Cada elemento debe tener una propiedad `idKey` única. |
+| `value` | `object[]` | `[]` | No | Elementos actualmente seleccionados. Debe ser un subconjunto de `items`. |
+| `label` | `string` | — | No | Etiqueta de cabecera renderizada encima del disparador. |
+| `placeholder` | `string` | — | No | Texto de marcador de posición mostrado dentro del disparador cuando no hay nada seleccionado. |
+| `displayKey` | `string \| string[]` | — | No | Clave(s) de cada elemento usadas para construir la cadena de visualización. Acepta una sola clave o un array de claves unidas por un espacio. Recurre a `code`, `name`, `label` o `idKey` cuando se omite. |
+| `valueKey` | `string` | — | No | Clave usada para renderizar la etiqueta del tag (sobreescribe `displayKey` dentro de los tags). |
+| `idKey` | `string` | `'id'` | No | Clave usada como identificador único para cada elemento. |
+| `type` | `string` | — | No | Cuando se proporciona, activa el modo filter-key: `updateFilter` se llama con un actualizador de estado que parchea `prev[type]`. |
+| `updateFilter` | `Function` | — | Yes | Manejador de cambio de selección. En modo directo recibe el nuevo `object[]`; en modo filter-key recibe un actualizador `(prev) => next`. |
+| `searchPlaceholder` | `string` | `'Cerca...'` | No | Marcador de posición para el input de búsqueda dentro del desplegable. |
+| `noResultsText` | `string` | `'Nessun risultato'` | No | Texto mostrado cuando la búsqueda no coincide con ningún elemento. |
+| `classNames` | `object` | `{}` | No | Sobreescrituras parciales de nombres de clase fusionadas con los predeterminados. Ver **Claves de Class Name** abajo. |
+
+### Claves de Class Name
+
+Todas las claves son opcionales. Las claves no especificadas recurren a los predeterminados definidos en el código fuente.
+
+| Key | Targets |
+|---|---|
+| `container` | `<div>` más externo |
+| `label` | `<div>` de la etiqueta de cabecera |
+| `trigger` | `<div>` del disparador al hacer clic |
+| `placeholder` | `<span>` del marcador de posición |
+| `tag` | `<span>` de cada tag de elemento seleccionado |
+| `tagButton` | Botón de eliminación dentro de cada tag |
+| `chevron` | Icono del chevron |
+| `dropdown` | `<div>` del desplegable |
+| `searchInput` | `<input>` de búsqueda |
+| `list` | `<ul>` |
+| `listItem` | Cada `<li>` |
+| `listItemSelected` | Añadido al `<li>` cuando el elemento está seleccionado |
+| `noResults` | `<li>` de "Sin resultados" |
+
+## CSS Variables
+
+| Variable | Default | Effect |
+|---|---|---|
+| `--color-input-bg` | `#f9fafb` | Fondo del desplegable (`bg-input-bg`) |
+| `--color-input-border` | `#d1d5db` | Borde del desplegable (`border-input-border`) |
+| `--text-input-label` | `14px` | Tamaño de fuente de la etiqueta (`text-input-label`) |
+| `--color-color-label` | `#111827` | Color del texto de la etiqueta (`text-color-label`) |
+
+## Usage
+
+```jsx
+import { useState } from 'react';
+import { MultiSelect } from 'thecore-auth';
+
+const TAGS = [
+  { id: 1, name: 'React' },
+  { id: 2, name: 'TypeScript' },
+  { id: 3, name: 'Tailwind' },
+  { id: 4, name: 'Vite' },
+];
+
+function TechStackPicker() {
+  const [selected, setSelected] = useState([]);
+
+  return (
+    <div className="w-80">
+      <MultiSelect
+        label="Tech stack"
+        items={TAGS}
+        value={selected}
+        placeholder="Select technologies…"
+        displayKey="name"
+        idKey="id"
+        updateFilter={setSelected}
+        searchPlaceholder="Search…"
+        noResultsText="No technologies found"
+      />
+      <p className="text-xs text-slate-400">
+        Selected: {selected.map((t) => t.name).join(', ') || 'none'}
+      </p>
+    </div>
+  );
+}
+```
+
+### Filter-key mode
+
+```jsx
+// Manage a composite filter object with multiple MultiSelect instances
+const [filters, setFilters] = useState({ tags: [], categories: [] });
+
+<MultiSelect
+  items={TAGS}
+  value={filters.tags}
+  type="tags"
+  updateFilter={setFilters}
+  displayKey="name"
+  idKey="id"
+  placeholder="Filter by tag…"
+/>
+```
+
+## Notes
+
+- El input de búsqueda se enfoca automáticamente cuando se abre el desplegable.
+- Hacer clic fuera del componente cierra el desplegable mediante `useClickOutside` de `src/hooks/ui/useClickOutside`.
+- El icono del chevron rota 180° cuando el desplegable está abierto (clase Tailwind `rotate-180`).
+- `EMPTY_ARRAY` es una constante a nivel de módulo usada como valor predeterminado para `value` para preservar la estabilidad referencial y evitar re-renderizados innecesarios.
+- `displayKey` como array combina múltiples campos (`['firstName', 'lastName']` → `"John Doe"`); los valores de campo falsy se filtran antes de unirse.
+- Los valores predeterminados de `searchPlaceholder` y `noResultsText` están en italiano — sobrescríbelos para otras configuraciones regionales.

--- a/docs/es/components/SingleSelect.md
+++ b/docs/es/components/SingleSelect.md
@@ -1,0 +1,57 @@
+# SingleSelect
+
+> **English:** [docs/components/SingleSelect.md](../../components/SingleSelect.md) | **Versione italiana:** [docs/it/components/SingleSelect.md](../it/components/SingleSelect.md)
+
+## Overview
+
+Un selector de valor único completamente controlado, renderizado como una pila vertical de botones. Cada opción se muestra como una pastilla en mayúsculas; la opción activa se resalta en azul. Diseñado para conjuntos de opciones pequeños y enumerables donde todas las opciones deben ser visibles de un vistazo (p. ej., paneles de filtros, selectores de configuración).
+
+## Import
+
+```js
+import { SingleSelect } from 'thecore-auth';
+```
+
+## Props
+
+| Name | Type | Default | Required | Description |
+|---|---|---|---|---|
+| `options` | `string[]` | `[]` | No | Array de cadenas de texto a renderizar como botones seleccionables. |
+| `value` | `string` | — | Yes | La opción actualmente seleccionada. Debe coincidir con una de las cadenas en `options`. |
+| `onChange` | `(selected: string) => void` | — | Yes | Se llama con la cadena de la opción pulsada cuando el usuario selecciona un nuevo valor. |
+
+## CSS Variables
+
+`SingleSelect` no utiliza propiedades CSS personalizadas de `src/css/index.css`. Los estilos activo e inactivo son clases Tailwind codificadas directamente (`bg-blue-500`, `bg-white`, `border-blue-500`, `border-slate-100`).
+
+## Usage
+
+```jsx
+import { useState } from 'react';
+import { SingleSelect } from 'thecore-auth';
+
+const ROLES = ['Admin', 'Editor', 'Viewer'];
+
+function RolePicker() {
+  const [role, setRole] = useState('Viewer');
+
+  return (
+    <div className="w-48">
+      <p className="mb-2 text-sm font-medium text-slate-600">Select role</p>
+      <SingleSelect
+        options={ROLES}
+        value={role}
+        onChange={setRole}
+      />
+      <p className="mt-3 text-xs text-slate-400">Selected: {role}</p>
+    </div>
+  );
+}
+```
+
+## Notes
+
+- Todos los botones se renderizan con `type="button"` para evitar el envío accidental del formulario.
+- La comprobación del estado activo es una comparación de igualdad estricta (`value === option`) — los valores deben ser únicos dentro de `options`.
+- Las etiquetas se renderizan en mayúsculas mediante `uppercase tracking-tighter` — la visualización siempre es la cadena sin procesar de `options`; no existe una asignación separada de `label`/`value`. Si necesitas separar las etiquetas de visualización de los valores internos, deriva `options` de un array mapeado y convierte en `onChange`.
+- No se aplica ningún contenedor de desplazamiento — para conjuntos de opciones grandes considera usar `MultiSelect` en su lugar.

--- a/docs/es/components/SwitchRadio.md
+++ b/docs/es/components/SwitchRadio.md
@@ -1,0 +1,79 @@
+# SwitchRadio
+
+> **English:** [docs/components/SwitchRadio.md](../../components/SwitchRadio.md) | **Versione italiana:** [docs/it/components/SwitchRadio.md](../it/components/SwitchRadio.md)
+
+## Overview
+
+Un interruptor de palanca renderizado como un `<button>` accesible. Soporta los modos **controlado** y **no controlado**:
+
+- **Controlado** — pasa una prop `value` y gestiona el estado externamente.
+- **No controlado** — omite `value`; el componente mantiene el estado internamente, inicializado con `defaultValue`.
+
+En ambos modos, el callback `onChange` se dispara en cada cambio.
+
+## Import
+
+```js
+import { SwitchRadio } from 'thecore-auth';
+```
+
+## Props
+
+| Name | Type | Default | Required | Description |
+|---|---|---|---|---|
+| `value` | `boolean` | — | No | Estado encendido/apagado controlado. Cuando se proporciona, el componente está en modo controlado. |
+| `defaultValue` | `boolean` | `false` | No | Estado inicial para el modo no controlado. Se reinicializa cuando cambia (solo en modo no controlado). |
+| `onChange` | `(next: boolean) => void` | — | No | Se llama con el nuevo valor booleano tras cada cambio, tanto en modo controlado como no controlado. |
+
+## CSS Variables
+
+`SwitchRadio` no utiliza propiedades CSS personalizadas de `src/css/index.css`. Los colores y tamaños son clases Tailwind codificadas directamente (`bg-blue-500`, `bg-gray-300`, `w-14`, `h-6`).
+
+## Usage
+
+### Controlled
+
+```jsx
+import { useState } from 'react';
+import { SwitchRadio } from 'thecore-auth';
+
+function NotificationSettings() {
+  const [enabled, setEnabled] = useState(false);
+
+  return (
+    <div className="flex items-center gap-3">
+      <span className="text-sm font-medium">Email notifications</span>
+      <SwitchRadio
+        value={enabled}
+        onChange={setEnabled}
+      />
+      <span className="text-sm text-slate-500">{enabled ? 'On' : 'Off'}</span>
+    </div>
+  );
+}
+```
+
+### Uncontrolled
+
+```jsx
+import { SwitchRadio } from 'thecore-auth';
+
+function FeatureFlag() {
+  return (
+    <div className="flex items-center gap-3">
+      <span className="text-sm font-medium">Beta features</span>
+      <SwitchRadio
+        defaultValue={true}
+        onChange={(next) => console.log('beta:', next)}
+      />
+    </div>
+  );
+}
+```
+
+## Notes
+
+- El botón se renderiza con `aria-pressed` reflejando el estado encendido/apagado actual, garantizando la compatibilidad con lectores de pantalla.
+- En modo no controlado, si el padre cambia `defaultValue`, el estado interno se resincroniza (mediante `useEffect`). Esto es intencional para casos donde el valor predeterminado se carga de forma asíncrona (p. ej., desde una API).
+- En modo controlado, el padre es el único responsable de actualizar `value`; el componente nunca muta la prop.
+- El componente no expone un par `name`/`value` compatible con la serialización nativa de formularios — conecta `onChange` a un input oculto si se requiere el envío del formulario.

--- a/docs/it/components/FileDropzone.md
+++ b/docs/it/components/FileDropzone.md
@@ -1,0 +1,73 @@
+# FileDropzone
+
+> **English:** [docs/components/FileDropzone.md](../../components/FileDropzone.md) | **Versión española:** [docs/es/components/FileDropzone.md](../es/components/FileDropzone.md)
+
+## Overview
+
+Una zona di caricamento file tramite drag-and-drop. Gestisce gli eventi `dragenter`, `dragover`, `dragleave` e `drop` e inoltra i file selezionati — trascinati o scelti tramite il dialogo nativo del file — come `Array<File>` al callback `onFilesSelect`. Un bordo animato appare durante un trascinamento attivo. Tutte le aree visive sono personalizzabili tramite appositi prop di stile.
+
+## Import
+
+```js
+import { FileDropzone } from 'thecore-auth';
+```
+
+## Props
+
+| Name | Type | Default | Required | Description |
+|---|---|---|---|---|
+| `onFilesSelect` | `(files: File[]) => void` | — | Yes | Chiamato con un `Array<File>` ogni volta che l'utente trascina o seleziona file. |
+| `id` | `string` | `'dropzone-file'` | No | Attributo `id` dell'`<input type="file">` nascosto. |
+| `containerStyle` | `string` | `'flex items-center justify-center w-full relative h-full'` | No | Stringa di classi per il `<div>` più esterno. |
+| `labelStyle` | `string` | Vedi sotto | No | Stringa di classi per il `<label>` che racchiude l'area visibile della dropzone. Include per default l'interpolazione dello stato drag-active. |
+| `dropzoneStyle` | `string` | `'flex flex-col items-center justify-center text-body px-6 text-center pt-5 pb-6 pointer-events-none'` | No | Stringa di classi per il blocco di contenuto interno (icona + testo). |
+| `dragActiveStyle` | `string` | `'absolute w-full h-full top-0 left-0 rounded-2xl border-2 border-primary-strong/70 animate-pulse'` | No | Stringa di classi per il `<div>` overlay visualizzato durante un trascinamento attivo. |
+
+**`labelStyle` predefinito:**
+```
+flex flex-col items-center justify-center w-full h-full rounded-2xl transition-all
+duration-300 bg-slate-100/80 shadow-lg border border-slate-300 rounded-base
+cursor-pointer hover:bg-slate-200/80 hover:border-slate-500 hover:shadow-xl
+[drag-active: bg-slate-200/80 border-slate-600 shadow-xl shadow-primary-strong]
+```
+
+## CSS Variables
+
+`FileDropzone` non utilizza proprietà CSS personalizzate da `src/css/index.css`. Tutto lo stile è espresso tramite classi di utilità Tailwind nei valori predefiniti dei prop.
+
+## Usage
+
+```jsx
+import { useState } from 'react';
+import { FileDropzone } from 'thecore-auth';
+
+function UploadPanel() {
+  const [files, setFiles] = useState([]);
+
+  const handleFiles = (selected) => {
+    setFiles((prev) => [...prev, ...selected]);
+  };
+
+  return (
+    <div className="h-64 w-full max-w-lg mx-auto">
+      <FileDropzone onFilesSelect={handleFiles} />
+
+      {files.length > 0 && (
+        <ul className="mt-4 text-sm text-slate-600 space-y-1">
+          {files.map((f, i) => (
+            <li key={i}>{f.name} — {(f.size / 1024).toFixed(1)} KB</li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+```
+
+## Notes
+
+- L'`<input type="file">` nascosto ha l'attributo `multiple`, quindi gli utenti possono sempre selezionare più di un file indipendentemente dal percorso drag-and-drop.
+- Gli eventi di trascinamento (`dragenter`, `dragover`, `dragleave`) sono gestiti con `useCallback` per evitare di ricreare gli handler ad ogni render.
+- L'overlay drag-active intercetta gli eventi puntatore durante un trascinamento per impedire al cursore di uscire dai confini della dropzone; viene rimosso immediatamente su `drop` o `dragleave`.
+- L'icona di caricamento (`SlCloudUpload`) è importata da `react-icons/sl` — assicurarsi che questo pacchetto sia disponibile nel progetto che consuma la libreria.
+- Il testo dell'interfaccia all'interno del componente è attualmente in italiano ("Clicca per caricare…"); sovrascrivere `dropzoneStyle` o fare un fork del componente se si ha bisogno di una lingua diversa.

--- a/docs/it/components/Input.md
+++ b/docs/it/components/Input.md
@@ -1,0 +1,92 @@
+# Input
+
+> **English:** [docs/components/Input.md](../../components/Input.md) | **Versión española:** [docs/es/components/Input.md](../es/components/Input.md)
+
+## Overview
+
+Un input di testo controllato che racchiude l'elemento nativo `<input>`. Limita il `type` a un elenco sicuro di valori consentiti e applica i design token definiti tramite variabili CSS del progetto. Qualsiasi classe può essere sostituita tramite `overrideStyle` o estesa tramite `inputStyle`.
+
+## Import
+
+```js
+import { Input } from 'thecore-auth';
+```
+
+## Props
+
+| Name | Type | Default | Required | Description |
+|---|---|---|---|---|
+| `inputType` | `'text' \| 'email' \| 'password' \| 'search' \| 'tel' \| 'url'` | `'text'` | No | Tipo nativo dell'input. Ritorna a `'text'` se viene fornito un valore non valido. |
+| `inputId` | `string` | — | No | Attributo `id`; associare con un `InputLabel` per l'accessibilità. |
+| `inputName` | `string` | — | No | Attributo `name` per la sottomissione del form. |
+| `inputValue` | `string` | — | Yes | Valore controllato. |
+| `inputChange` | `(e: ChangeEvent) => void` | — | Yes | Handler `onChange`. |
+| `inputPlaceholder` | `string` | — | No | Testo segnaposto. |
+| `inputRequired` | `boolean` | `true` | No | Corrisponde all'attributo nativo `required`. |
+| `autoFocus` | `boolean` | — | No | Mette a fuoco automaticamente il campo al montaggio. |
+| `inputStyle` | `string` | `''` | No | Classi Tailwind aggiuntive accodate alla stringa di classi predefinita. |
+| `overrideStyle` | `string` | — | No | Sostituisce l'intera stringa di classi predefinita quando specificata. |
+| `disabled` | `boolean` | — | No | Disabilita l'input. |
+
+## CSS Variables
+
+| Variable | Default | Effect |
+|---|---|---|
+| `--color-input-bg` | `#f9fafb` | Sfondo dell'input (`bg-input-bg`) |
+| `--color-input-border` | `#d1d5db` | Colore del bordo (`border-input-border`) |
+| `--color-input-text` | `#111827` | Colore del testo (`text-input-text`) |
+| `--text-input-placeholder` | `14px` | Dimensione del font del segnaposto (`text-input-placeholder`) |
+| `--input-radius` | `8px` | Raggio del bordo (`.input-rounded`) |
+| `--padding-input` | `10px` | Padding interno (`p-input`) |
+| `--color-primary` | `#f56907` | Colore del focus ring e del bordo |
+| `--shadow-primary-input` | `inset 0 1px 1px …` | Box-shadow al focus |
+
+> Sovrascrivere qualsiasi variabile in `:root` o in un selettore padre si propaga automaticamente a tutte le istanze di `Input` in quell'ambito.
+
+## Usage
+
+```jsx
+import { useState } from 'react';
+import { Input, InputLabel } from 'thecore-auth';
+
+function LoginFields() {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+
+  return (
+    <form onSubmit={(e) => e.preventDefault()}>
+      <div className="flex flex-col gap-1 mb-4">
+        <InputLabel label="Email" labelId="email" />
+        <Input
+          inputType="email"
+          inputId="email"
+          inputName="email"
+          inputPlaceholder="you@example.com"
+          inputValue={email}
+          inputChange={(e) => setEmail(e.target.value)}
+        />
+      </div>
+
+      <div className="flex flex-col gap-1">
+        <InputLabel label="Password" labelId="password" />
+        <Input
+          inputType="password"
+          inputId="password"
+          inputName="password"
+          inputPlaceholder="••••••••"
+          inputValue={password}
+          inputChange={(e) => setPassword(e.target.value)}
+          inputStyle="font-mono tracking-widest"
+        />
+      </div>
+    </form>
+  );
+}
+```
+
+## Notes
+
+- `inputType` viene validato rispetto a `['text', 'email', 'password', 'search', 'tel', 'url']`. Qualsiasi valore non supportato torna silenziosamente a `'text'`.
+- `inputRequired` ha valore predefinito `true` — passare `inputRequired={false}` esplicitamente per i campi opzionali.
+- Usare `overrideStyle` per sostituire completamente la stringa di classi predefinita quando i design token non si applicano.
+- Usare `inputStyle` per aggiungere classi senza perdere lo stile predefinito basato sui token.

--- a/docs/it/components/InputDate.md
+++ b/docs/it/components/InputDate.md
@@ -1,0 +1,96 @@
+# InputDate
+
+> **English:** [docs/components/InputDate.md](../../components/InputDate.md) | **Versión española:** [docs/es/components/InputDate.md](../es/components/InputDate.md)
+
+## Overview
+
+Un `<input type="date">` con etichetta racchiuso in un contenitore flex column. Applica i design token del progetto guidati da variabili CSS (sfondo, bordo, focus ring, padding, raggio) e supporta uno stato disabilitato con stili dedicati di opacità e cursore. Uno slot opzionale `children` permette di aggiungere messaggi di validazione o testo di aiuto sotto l'input.
+
+## Import
+
+```js
+import { InputDate } from 'thecore-auth';
+```
+
+## Props
+
+| Name | Type | Default | Required | Description |
+|---|---|---|---|---|
+| `id` | `string` | — | Yes | Attributo `id` dell'input; usato anche come `htmlFor` dell'etichetta. |
+| `name` | `string` | — | No | Attributo `name` per la sottomissione del form. |
+| `value` | `string` | `''` | No | Valore controllato nel formato `YYYY-MM-DD`. |
+| `onChange` | `(e: ChangeEvent) => void` | — | Yes | Handler `onChange`. |
+| `disabled` | `boolean` | — | No | Disabilita l'input; applica automaticamente uno stile attenuato. |
+| `required` | `boolean` | — | No | Corrisponde all'attributo nativo `required`. |
+| `title` | `string` | — | No | Testo dell'etichetta renderizzato sopra l'input. |
+| `containerStyle` | `string` | `'flex flex-col gap-1 mx-auto w-full'` | No | Stringa di classi per il `<div>` wrapper. |
+| `labelStyle` | `string` | Vedi sotto | No | Stringa di classi per il `<label>`. |
+| `inputStyle` | `string` | Vedi sotto | No | Stringa di classi per l'`<input>`. |
+| `children` | `ReactNode` | — | No | Contenuto renderizzato sotto l'input (es. messaggi di errore di validazione). |
+
+**`labelStyle` predefinito:** `mb-1 text-input-label font-medium text-color-label`
+
+**`inputStyle` predefinito:** `bg-input-bg border border-input-border rounded-lg text-input-text placeholder:text-input-placeholder rounded-input focus:ring focus:ring-primary focus:border-primary focus:outline-none focus:shadow-[var(--shadow-primary-input)] block w-full h-[43px] p-input disabled:bg-gray-100 disabled:text-gray-400 disabled:cursor-not-allowed disabled:opacity-60`
+
+## CSS Variables
+
+| Variable | Default | Effect |
+|---|---|---|
+| `--color-input-bg` | `#f9fafb` | Sfondo dell'input (`bg-input-bg`) |
+| `--color-input-border` | `#d1d5db` | Colore del bordo (`border-input-border`) |
+| `--color-input-text` | `#111827` | Colore del testo (`text-input-text`) |
+| `--text-input-label` | `14px` | Dimensione del font dell'etichetta (`text-input-label`) |
+| `--color-color-label` | `#111827` | Colore del testo dell'etichetta (`text-color-label`) |
+| `--input-radius` | `8px` | Raggio del bordo (`rounded-input`) |
+| `--padding-input` | `10px` | Padding interno (`p-input`) |
+| `--color-primary` | `#f56907` | Colore del focus ring e del bordo |
+| `--shadow-primary-input` | `inset 0 1px 1px …` | Box-shadow al focus |
+
+## Usage
+
+```jsx
+import { useState } from 'react';
+import { InputDate } from 'thecore-auth';
+
+function BookingForm() {
+  const [checkIn, setCheckIn] = useState('');
+  const [error, setError] = useState('');
+
+  const handleChange = (e) => {
+    setCheckIn(e.target.value);
+    setError('');
+  };
+
+  const validate = () => {
+    if (!checkIn) setError('Check-in date is required.');
+  };
+
+  return (
+    <form onSubmit={(e) => { e.preventDefault(); validate(); }}>
+      <InputDate
+        id="check-in"
+        name="checkIn"
+        title="Check-in date"
+        value={checkIn}
+        onChange={handleChange}
+        required
+      >
+        {error && (
+          <p className="text-red-500 text-xs mt-1">{error}</p>
+        )}
+      </InputDate>
+
+      <button type="submit" className="mt-4 px-4 py-2 bg-primary text-white rounded">
+        Book
+      </button>
+    </form>
+  );
+}
+```
+
+## Notes
+
+- `value` ha come valore predefinito una stringa vuota `""` quando viene passato `undefined`, prevenendo l'avviso React di passaggio da componente non controllato a controllato.
+- Lo stato disabilitato applica `bg-gray-100`, `text-gray-400`, `cursor-not-allowed` e `opacity-60` attraverso l'`inputStyle` predefinito — non è necessario alcun prop aggiuntivo.
+- Sovrascrivere `containerStyle`, `labelStyle` o `inputStyle` singolarmente; tutte e tre le stringhe predefinite rimangono disponibili come riferimento di partenza.
+- `children` viene renderizzato all'interno dello slot `children` dell'`InputDate` della data finale da `InputStartEndDate` per visualizzare gli errori di validazione dell'intervallo di date — vedere il riferimento di `InputStartEndDate` per il pattern composto.

--- a/docs/it/components/InputLabel.md
+++ b/docs/it/components/InputLabel.md
@@ -1,0 +1,68 @@
+# InputLabel
+
+> **English:** [docs/components/InputLabel.md](../../components/InputLabel.md) | **Versión española:** [docs/es/components/InputLabel.md](../es/components/InputLabel.md)
+
+## Overview
+
+Un sottile wrapper attorno all'elemento HTML `<label>`. Applica tipografia e visibilità guidate dai design token e collega l'input associato tramite `htmlFor`. La visualizzazione predefinita (`block` o `none`) è controllata dalla variabile CSS `--label-display`, rendendo semplice nascondere le etichette globalmente nei layout compatti senza rimuoverle dal DOM (l'accessibilità viene preservata).
+
+## Import
+
+```js
+import { InputLabel } from 'thecore-auth';
+```
+
+## Props
+
+| Name | Type | Default | Required | Description |
+|---|---|---|---|---|
+| `label` | `string` | — | Yes | Contenuto testuale dell'etichetta. |
+| `labelId` | `string` | — | Yes | Valore dell'attributo `htmlFor`; deve corrispondere all'`id` dell'input associato. |
+| `labelStyle` | `string` | `''` | No | Classi Tailwind aggiuntive accodate alla stringa di classi predefinita. |
+| `overrideStyle` | `string` | — | No | Sostituisce l'intera stringa di classi predefinita quando specificata. |
+
+## CSS Variables
+
+| Variable | Default | Effect |
+|---|---|---|
+| `--label-display` | `block` | Controlla la visibilità dell'etichetta tramite `.show-label { display: var(--label-display) }` |
+| `--text-input-label` | `14px` | Dimensione del font (`text-input-label`) |
+| `--color-color-label` | `#111827` | Colore del testo (`text-color-label`) |
+
+> Impostare `--label-display: none` su uno scope padre per nascondere tutte le etichette mantenendole nel DOM per i lettori di schermo.
+
+## Usage
+
+```jsx
+import { Input, InputLabel } from 'thecore-auth';
+import { useState } from 'react';
+
+function SearchField() {
+  const [query, setQuery] = useState('');
+
+  return (
+    <div className="flex flex-col gap-1 w-full max-w-sm">
+      <InputLabel
+        label="Search"
+        labelId="global-search"
+        labelStyle="text-slate-600"
+      />
+      <Input
+        inputType="search"
+        inputId="global-search"
+        inputName="q"
+        inputPlaceholder="Type to search…"
+        inputValue={query}
+        inputChange={(e) => setQuery(e.target.value)}
+        inputRequired={false}
+      />
+    </div>
+  );
+}
+```
+
+## Notes
+
+- Associare sempre `labelId` con l'`id` dell'input corrispondente per soddisfare i requisiti di accessibilità.
+- `overrideStyle` rimuove la classe `.show-label`, il che significa che `--label-display` non controlla più la visibilità — usare `labelStyle` per estendere invece.
+- La classe di utilità `.show-label` è definita in `src/css/index.css` e legge `--label-display` dal tema.

--- a/docs/it/components/InputStartEndDate.md
+++ b/docs/it/components/InputStartEndDate.md
@@ -1,0 +1,94 @@
+# InputStartEndDate
+
+> **English:** [docs/components/InputStartEndDate.md](../../components/InputStartEndDate.md) | **Versión española:** [docs/es/components/InputStartEndDate.md](../es/components/InputStartEndDate.md)
+
+## Overview
+
+Un selettore di intervallo di date che compone due componenti `InputDate` affiancati. Il campo della data finale può essere nascosto con `endDateShow={false}`, e una stringa di errore di validazione (`dateError`) viene renderizzata sotto l'input della data finale. Entrambi i campi condividono lo stesso handler `onChange`, e i prop `disabled`, `required` e `labelStyle`, mentre ciascun campo può ricevere i propri override di stile per container e input.
+
+## Import
+
+```js
+import { InputStartEndDate } from 'thecore-auth';
+```
+
+## Props
+
+| Name | Type | Default | Required | Description |
+|---|---|---|---|---|
+| `startId` | `string` | — | Yes | `id` dell'input della data iniziale. |
+| `endId` | `string` | — | No | `id` dell'input della data finale. |
+| `startName` | `string` | — | No | `name` dell'input della data iniziale per la sottomissione del form. |
+| `endName` | `string` | — | No | `name` dell'input della data finale per la sottomissione del form. |
+| `startValue` | `string` | — | No | Valore controllato della data iniziale (`YYYY-MM-DD`). |
+| `endValue` | `string` | — | No | Valore controllato della data finale (`YYYY-MM-DD`). |
+| `onChange` | `(e: ChangeEvent) => void` | — | Yes | Handler `onChange` condiviso per entrambi i campi. |
+| `disabled` | `boolean` | — | No | Disabilita entrambi i campi. |
+| `required` | `boolean` | — | No | Rende entrambi i campi obbligatori. |
+| `dateError` | `string` | — | No | Messaggio di validazione mostrato sotto il campo della data finale in rosso. |
+| `startTitle` | `string` | — | No | Testo dell'etichetta per il campo della data iniziale. |
+| `endTitle` | `string` | — | No | Testo dell'etichetta per il campo della data finale. |
+| `containerStyle` | `string` | `'flex gap-4 mx-auto w-full mb-4'` | No | Stringa di classi per il wrapper esterno. |
+| `startContainerStyle` | `string` | — | No | `containerStyle` inoltrato all'`InputDate` iniziale. |
+| `endContainerStyle` | `string` | — | No | `containerStyle` inoltrato all'`InputDate` finale. |
+| `startStyle` | `string` | — | No | `inputStyle` inoltrato all'`InputDate` iniziale. |
+| `endStyle` | `string` | — | No | `inputStyle` inoltrato all'`InputDate` finale. |
+| `labelStyle` | `string` | — | No | `labelStyle` inoltrato a entrambi i componenti `InputDate`. |
+| `endDateShow` | `boolean` | `true` | No | Impostare a `false` per renderizzare solo il campo della data iniziale. |
+| `children` | `ReactNode` | — | No | Contenuto aggiuntivo aggiunto dopo entrambi i campi data all'interno del wrapper. |
+
+## CSS Variables
+
+`InputStartEndDate` delega tutto il rendering a `InputDate` — vedere [InputDate CSS Variables](./InputDate.md#css-variables) per l'elenco completo.
+
+## Usage
+
+```jsx
+import { useState } from 'react';
+import { InputStartEndDate } from 'thecore-auth';
+
+function VacationPicker() {
+  const [dates, setDates] = useState({ start: '', end: '' });
+  const [error, setError] = useState('');
+
+  const handleChange = (e) => {
+    const { name, value } = e.target;
+    setDates((prev) => {
+      const next = { ...prev, [name]: value };
+
+      // Validate: end must not precede start
+      if (next.start && next.end && next.end < next.start) {
+        setError('End date must be after start date.');
+      } else {
+        setError('');
+      }
+
+      return next;
+    });
+  };
+
+  return (
+    <InputStartEndDate
+      startId="vacation-start"
+      endId="vacation-end"
+      startName="start"
+      endName="end"
+      startTitle="From"
+      endTitle="To"
+      startValue={dates.start}
+      endValue={dates.end}
+      onChange={handleChange}
+      dateError={error}
+      required
+    />
+  );
+}
+```
+
+## Notes
+
+- `onChange` riceve un `ChangeEvent` DOM standard; usare `e.target.name` per distinguere tra i due campi (abbinare con `startName` / `endName`).
+- `dateError` viene renderizzato all'interno dello slot `children` dell'`InputDate` della data finale come `<p className="text-red-500 text-[13px] mt-1">`. Fornire `null` o omettere il prop per sopprimerlo.
+- Impostare `endDateShow={false}` quando si ha bisogno di un selettore a data singola ma si vuole mantenere le stesse dimensioni del campo e il layout della variante a intervallo.
+- `children` viene aggiunto dopo entrambi i campi data nel wrapper esterno — usarlo per azioni (es. un pulsante "Cancella") o messaggi supplementari.
+- Entrambe le istanze di `InputDate` condividono lo stesso `onChange`, `disabled`, `required` e `labelStyle` — non possono essere configurati in modo indipendente per questi prop.

--- a/docs/it/components/MultiSelect.md
+++ b/docs/it/components/MultiSelect.md
@@ -1,0 +1,126 @@
+# MultiSelect
+
+> **English:** [docs/components/MultiSelect.md](../../components/MultiSelect.md) | **Versión española:** [docs/es/components/MultiSelect.md](../es/components/MultiSelect.md)
+
+## Overview
+
+Un dropdown con ricerca e selezione multipla. Gli elementi selezionati appaiono come tag rimovibili all'interno del trigger. Cliccando il trigger si apre un dropdown con un input di ricerca e un elenco scorrevole. Cliccando un elemento si attiva/disattiva la sua selezione; cliccando fuori si chiude il dropdown (`useClickOutside`).
+
+Supporta due modalità di selezione:
+- **Modalità diretta** — `updateFilter` riceve direttamente il nuovo `Array` di elementi selezionati.
+- **Modalità filter-key** — passare una stringa `type` e `updateFilter` riceve una funzione state-updater che aggiorna un oggetto filtro con chiave.
+
+## Import
+
+```js
+import { MultiSelect } from 'thecore-auth';
+```
+
+## Props
+
+| Name | Type | Default | Required | Description |
+|---|---|---|---|---|
+| `items` | `object[]` | — | Yes | Elenco completo delle opzioni da visualizzare. Ogni elemento deve avere una proprietà `idKey` univoca. |
+| `value` | `object[]` | `[]` | No | Elementi attualmente selezionati. Deve essere un sottoinsieme di `items`. |
+| `label` | `string` | — | No | Etichetta intestazione renderizzata sopra il trigger. |
+| `placeholder` | `string` | — | No | Testo segnaposto mostrato all'interno del trigger quando nulla è selezionato. |
+| `displayKey` | `string \| string[]` | — | No | Chiave/i di ogni elemento usata per costruire la stringa di visualizzazione. Accetta una singola chiave o un array di chiavi unite da uno spazio. Torna a `code`, `name`, `label` o `idKey` se omesso. |
+| `valueKey` | `string` | — | No | Chiave usata per renderizzare l'etichetta del tag (sovrascrive `displayKey` all'interno dei tag). |
+| `idKey` | `string` | `'id'` | No | Chiave usata come identificatore univoco per ogni elemento. |
+| `type` | `string` | — | No | Quando fornito, attiva la modalità filter-key: `updateFilter` viene chiamato con uno state-updater che aggiorna `prev[type]`. |
+| `updateFilter` | `Function` | — | Yes | Handler del cambio di selezione. In modalità diretta riceve il nuovo `object[]`; in modalità filter-key riceve uno state-updater `(prev) => next`. |
+| `searchPlaceholder` | `string` | `'Cerca...'` | No | Segnaposto per l'input di ricerca nel dropdown. |
+| `noResultsText` | `string` | `'Nessun risultato'` | No | Testo mostrato quando la query di ricerca non corrisponde ad alcun elemento. |
+| `classNames` | `object` | `{}` | No | Override parziali dei nomi di classe uniti ai valori predefiniti. Vedere **Class Name Keys** di seguito. |
+
+### Class Name Keys
+
+Tutte le chiavi sono opzionali. Le chiavi non specificate tornano ai valori predefiniti elencati nel sorgente.
+
+| Key | Targets |
+|---|---|
+| `container` | `<div>` più esterno |
+| `label` | `<div>` dell'etichetta intestazione |
+| `trigger` | `<div>` trigger cliccabile |
+| `placeholder` | `<span>` del segnaposto |
+| `tag` | Ogni `<span>` del tag dell'elemento selezionato |
+| `tagButton` | Pulsante di rimozione all'interno di ogni tag |
+| `chevron` | Icona chevron |
+| `dropdown` | `<div>` del dropdown |
+| `searchInput` | `<input>` di ricerca |
+| `list` | `<ul>` |
+| `listItem` | Ogni `<li>` |
+| `listItemSelected` | Aggiunto al `<li>` quando l'elemento è selezionato |
+| `noResults` | `<li>` "Nessun risultato" |
+
+## CSS Variables
+
+| Variable | Default | Effect |
+|---|---|---|
+| `--color-input-bg` | `#f9fafb` | Sfondo del dropdown (`bg-input-bg`) |
+| `--color-input-border` | `#d1d5db` | Bordo del dropdown (`border-input-border`) |
+| `--text-input-label` | `14px` | Dimensione del font dell'etichetta (`text-input-label`) |
+| `--color-color-label` | `#111827` | Colore del testo dell'etichetta (`text-color-label`) |
+
+## Usage
+
+```jsx
+import { useState } from 'react';
+import { MultiSelect } from 'thecore-auth';
+
+const TAGS = [
+  { id: 1, name: 'React' },
+  { id: 2, name: 'TypeScript' },
+  { id: 3, name: 'Tailwind' },
+  { id: 4, name: 'Vite' },
+];
+
+function TechStackPicker() {
+  const [selected, setSelected] = useState([]);
+
+  return (
+    <div className="w-80">
+      <MultiSelect
+        label="Tech stack"
+        items={TAGS}
+        value={selected}
+        placeholder="Select technologies…"
+        displayKey="name"
+        idKey="id"
+        updateFilter={setSelected}
+        searchPlaceholder="Search…"
+        noResultsText="No technologies found"
+      />
+      <p className="text-xs text-slate-400">
+        Selected: {selected.map((t) => t.name).join(', ') || 'none'}
+      </p>
+    </div>
+  );
+}
+```
+
+### Filter-key mode
+
+```jsx
+// Manage a composite filter object with multiple MultiSelect instances
+const [filters, setFilters] = useState({ tags: [], categories: [] });
+
+<MultiSelect
+  items={TAGS}
+  value={filters.tags}
+  type="tags"
+  updateFilter={setFilters}
+  displayKey="name"
+  idKey="id"
+  placeholder="Filter by tag…"
+/>
+```
+
+## Notes
+
+- L'input di ricerca viene messo a fuoco automaticamente all'apertura del dropdown.
+- Cliccando fuori dal componente si chiude il dropdown tramite `useClickOutside` da `src/hooks/ui/useClickOutside`.
+- L'icona chevron ruota di 180° quando il dropdown è aperto (classe Tailwind `rotate-180`).
+- `EMPTY_ARRAY` è una costante a livello di modulo usata come valore predefinito per `value` per preservare la stabilità referenziale ed evitare re-render non necessari.
+- `displayKey` come array unisce più campi (`['firstName', 'lastName']` → `"John Doe"`); i valori di campo falsy vengono filtrati prima dell'unione.
+- I valori predefiniti di `searchPlaceholder` e `noResultsText` sono in italiano — sovrascriverli per altre lingue.

--- a/docs/it/components/SingleSelect.md
+++ b/docs/it/components/SingleSelect.md
@@ -1,0 +1,57 @@
+# SingleSelect
+
+> **English:** [docs/components/SingleSelect.md](../../components/SingleSelect.md) | **Versión española:** [docs/es/components/SingleSelect.md](../es/components/SingleSelect.md)
+
+## Overview
+
+Un selettore a valore singolo completamente controllato, renderizzato come una pila verticale di pulsanti. Ogni opzione viene visualizzata come una pill in maiuscolo; l'opzione attiva è evidenziata in blu. Pensato per insiemi di opzioni piccoli ed enumerabili in cui tutte le scelte devono essere visibili a colpo d'occhio (es. pannelli di filtro, selettori di configurazione).
+
+## Import
+
+```js
+import { SingleSelect } from 'thecore-auth';
+```
+
+## Props
+
+| Name | Type | Default | Required | Description |
+|---|---|---|---|---|
+| `options` | `string[]` | `[]` | No | Array di valori stringa da renderizzare come pulsanti selezionabili. |
+| `value` | `string` | — | Yes | L'opzione attualmente selezionata. Deve corrispondere a una delle stringhe in `options`. |
+| `onChange` | `(selected: string) => void` | — | Yes | Chiamato con la stringa dell'opzione cliccata quando l'utente seleziona un nuovo valore. |
+
+## CSS Variables
+
+`SingleSelect` non utilizza proprietà CSS personalizzate da `src/css/index.css`. Gli stili attivo e inattivo sono classi Tailwind codificate (`bg-blue-500`, `bg-white`, `border-blue-500`, `border-slate-100`).
+
+## Usage
+
+```jsx
+import { useState } from 'react';
+import { SingleSelect } from 'thecore-auth';
+
+const ROLES = ['Admin', 'Editor', 'Viewer'];
+
+function RolePicker() {
+  const [role, setRole] = useState('Viewer');
+
+  return (
+    <div className="w-48">
+      <p className="mb-2 text-sm font-medium text-slate-600">Select role</p>
+      <SingleSelect
+        options={ROLES}
+        value={role}
+        onChange={setRole}
+      />
+      <p className="mt-3 text-xs text-slate-400">Selected: {role}</p>
+    </div>
+  );
+}
+```
+
+## Notes
+
+- Tutti i pulsanti vengono renderizzati con `type="button"` per evitare la sottomissione accidentale del form.
+- Il controllo dello stato attivo è un confronto di uguaglianza stretta (`value === option`) — i valori devono essere univoci all'interno di `options`.
+- Le etichette vengono renderizzate in maiuscolo tramite `uppercase tracking-tighter` — la visualizzazione è sempre la stringa grezza da `options`; non esiste una mappatura separata `label`/`value`. Se è necessario separare le etichette di visualizzazione dai valori interni, derivare `options` da un array mappato e convertire in `onChange`.
+- Non viene applicato alcun contenitore di scorrimento — per insiemi di opzioni grandi considerare `MultiSelect`.

--- a/docs/it/components/SwitchRadio.md
+++ b/docs/it/components/SwitchRadio.md
@@ -1,0 +1,79 @@
+# SwitchRadio
+
+> **English:** [docs/components/SwitchRadio.md](../../components/SwitchRadio.md) | **Versión española:** [docs/es/components/SwitchRadio.md](../es/components/SwitchRadio.md)
+
+## Overview
+
+Uno switch toggle renderizzato come `<button>` accessibile. Supporta sia la modalità **controllata** che quella **non controllata**:
+
+- **Controllata** — passare un prop `value` e gestire lo stato esternamente.
+- **Non controllata** — omettere `value`; il componente mantiene lo stato internamente, inizializzato da `defaultValue`.
+
+In entrambe le modalità il callback `onChange` viene eseguito ad ogni toggle.
+
+## Import
+
+```js
+import { SwitchRadio } from 'thecore-auth';
+```
+
+## Props
+
+| Name | Type | Default | Required | Description |
+|---|---|---|---|---|
+| `value` | `boolean` | — | No | Stato on/off controllato. Quando fornito, il componente è in modalità controllata. |
+| `defaultValue` | `boolean` | `false` | No | Stato iniziale per la modalità non controllata. Viene reinizializzato ogni volta che cambia (solo in modalità non controllata). |
+| `onChange` | `(next: boolean) => void` | — | No | Chiamato con il nuovo valore booleano dopo ogni toggle, in entrambe le modalità controllata e non controllata. |
+
+## CSS Variables
+
+`SwitchRadio` non utilizza proprietà CSS personalizzate da `src/css/index.css`. I colori e le dimensioni sono classi Tailwind codificate (`bg-blue-500`, `bg-gray-300`, `w-14`, `h-6`).
+
+## Usage
+
+### Controlled
+
+```jsx
+import { useState } from 'react';
+import { SwitchRadio } from 'thecore-auth';
+
+function NotificationSettings() {
+  const [enabled, setEnabled] = useState(false);
+
+  return (
+    <div className="flex items-center gap-3">
+      <span className="text-sm font-medium">Email notifications</span>
+      <SwitchRadio
+        value={enabled}
+        onChange={setEnabled}
+      />
+      <span className="text-sm text-slate-500">{enabled ? 'On' : 'Off'}</span>
+    </div>
+  );
+}
+```
+
+### Uncontrolled
+
+```jsx
+import { SwitchRadio } from 'thecore-auth';
+
+function FeatureFlag() {
+  return (
+    <div className="flex items-center gap-3">
+      <span className="text-sm font-medium">Beta features</span>
+      <SwitchRadio
+        defaultValue={true}
+        onChange={(next) => console.log('beta:', next)}
+      />
+    </div>
+  );
+}
+```
+
+## Notes
+
+- Il pulsante viene renderizzato con `aria-pressed` che riflette lo stato on/off corrente, garantendo la compatibilità con i lettori di schermo.
+- In modalità non controllata, se il padre modifica `defaultValue` lo stato interno si risincronizza (tramite `useEffect`). Questo è intenzionale per i casi in cui il valore predefinito viene caricato in modo asincrono (es. da un'API).
+- In modalità controllata il padre è l'unico responsabile dell'aggiornamento di `value`; il componente stesso non modifica mai il prop.
+- Il componente non espone una coppia `name`/`value` compatibile con la serializzazione nativa dei form — collegare `onChange` a un input nascosto se è richiesta la sottomissione del form.


### PR DESCRIPTION
## Summary

- 8 input component reference files in EN + IT + ES (24 files total)
- Components covered: `Input`, `InputLabel`, `FileDropzone`, `SwitchRadio`, `InputDate`, `InputStartEndDate`, `SingleSelect`, `MultiSelect`
- Schema per file: Overview · Import · Props · CSS Variables · Usage · Notes
- Props and behavior read directly from `src/components/inputs/` — no guessed values
- CSS variables mapped from `src/css/index.css`

Closes #11