### PR TITLE
docs(components): add UI components reference docs

### DIFF
--- a/docs/components/Alert.md
+++ b/docs/components/Alert.md
@@ -1,0 +1,99 @@
+# Alert
+
+> [Versione italiana](../../docs/it/components/Alert.md) | [Versión española](../../docs/es/components/Alert.md)
+
+## Overview
+
+`Alert` is a fixed-position toast-style notification banner. It reads its state from `AlertContext` and `ConfigContext`, so it accepts no props. The banner includes a progress bar that drains over `alertTimeout` milliseconds, after which it auto-dismisses. On mobile/tablet devices with Sileo enabled, the alert is replaced by a native toast (see Notes).
+
+## Import
+
+```js
+import { Alert } from 'thecore-auth';
+```
+
+## Props
+
+This component accepts **no props**. Trigger it by calling `activeAlert` from `useAlert()`.
+
+| `useAlert()` value | Type | Signature | Description |
+|---|---|---|---|
+| `activeAlert` | `function` | `(type, message, customType?)` | Show the alert |
+| `closeAlert` | `function` | `()` | Dismiss the alert immediately |
+| `showAlert` | `boolean` | — | Whether the alert is currently visible |
+
+**Alert types** (`type` argument of `activeAlert`):
+
+| Value | Meaning |
+|---|---|
+| `'danger'` | Error / destructive action |
+| `'info'` | Neutral information |
+| `'success'` | Successful operation |
+| `'warning'` | Non-critical warning |
+
+## CSS Variables
+
+| Variable | Default | Description |
+|---|---|---|
+| `--color-danger` | `#FEE2E2` | Danger background |
+| `--color-danger-text` | `#B91C1C` | Danger text color |
+| `--color-danger-hover` | `#FECACA` | Danger close-button hover |
+| `--color-danger-progress` | `#F87171` | Danger progress bar |
+| `--color-info` | `#EFF6FF` | Info background |
+| `--color-info-text` | `#1D4ED8` | Info text color |
+| `--color-info-hover` | `#BFDBFE` | Info close-button hover |
+| `--color-info-progress` | `#60A5FA` | Info progress bar |
+| `--color-success` | `#ECFDF5` | Success background |
+| `--color-success-text` | `#15803D` | Success text color |
+| `--color-success-hover` | `#A7F3D0` | Success close-button hover |
+| `--color-success-progress` | `#34D399` | Success progress bar |
+| `--color-warning` | `#F9FAEB` | Warning background |
+| `--color-warning-text` | `#D97706` | Warning text color |
+| `--color-warning-hover` | `#FDE047` | Warning close-button hover |
+| `--color-warning-progress` | `#FACC15` | Warning progress bar |
+
+## Usage
+
+```jsx
+import { AlertProvider, useAlert, Alert } from 'thecore-auth';
+
+// Place <Alert /> once at the root of your app
+function App({ children }) {
+  return (
+    <AlertProvider>
+      {children}
+      <Alert />
+    </AlertProvider>
+  );
+}
+
+// Trigger from any component inside the tree
+function SaveButton() {
+  const { activeAlert } = useAlert();
+
+  async function handleSave() {
+    try {
+      await api.save();
+      activeAlert('success', 'Record saved successfully.');
+    } catch (err) {
+      activeAlert('danger', 'Save failed. Please try again.');
+    }
+  }
+
+  return <button onClick={handleSave}>Save</button>;
+}
+```
+
+### Force web alert on mobile
+
+```jsx
+// Pass a non-null customType to bypass the Sileo toast even on mobile
+activeAlert('warning', 'Session expiring soon.', 'web');
+```
+
+## Notes
+
+- The `alertTimeout` duration (milliseconds) is configured in `ConfigContext` via `public/config.json`. The progress bar drains linearly over that duration.
+- When `sileoToastEnabled` is `true` in config and the device type is `mobile` or `tablet`, `activeAlert` delegates to Sileo native toasts and `<Alert />` is never shown. Pass a non-null `customType` argument to force the web banner regardless.
+- Place `<Alert />` at the root of your component tree to ensure the fixed overlay stacks above all other content.
+- The component uses `role="alert"` for accessibility.

--- a/docs/components/Loader.md
+++ b/docs/components/Loader.md
@@ -1,0 +1,86 @@
+# Loader
+
+> [Versione italiana](../../docs/it/components/Loader.md) | [Versión española](../../docs/es/components/Loader.md)
+
+## Overview
+
+`Loader` is a full-screen animated overlay shown during initial app load. It reads `isLoading` from `LoadingContext` and `customLoginTimeout` from `ConfigContext`. The overlay fades in when loading starts and fades out (300 ms) when loading ends. A random gradient is picked from a built-in palette on each mount; the palette can be replaced or extended via props.
+
+## Import
+
+```js
+import { Loader } from 'thecore-auth';
+```
+
+## Props
+
+| Name | Type | Default | Required | Description |
+|---|---|---|---|---|
+| `gradients` | `string[]` | `undefined` | No | Replaces the entire built-in gradient list. If omitted, the default palette (plus `moreGradients`) is used |
+| `moreGradients` | `string[]` | `undefined` | No | Additional Tailwind gradient classes appended to the built-in list |
+| `containerSize` | `string` | `'h-[420px] w-[420px]'` | No | Tailwind size classes passed to the inner `LogoLoader` container |
+| `overlayStyle` | `string` | `undefined` | No | Replaces the default overlay positioning classes (`fixed top-0 … flex items-center justify-center z-999 transition-opacity duration-300`) |
+| `NewLogoLoader` | `ComponentType` | `undefined` | No | Custom component rendered instead of `LogoLoader` |
+| `Logo` | `ComponentType` | `undefined` | No | SVG/image component passed to `LogoLoader` as the centered logo |
+| `spinnerColor` | `string` | `'#60A5FA'` | No | Stroke color of the SVG ring in `LogoLoader` |
+
+## CSS Variables
+
+`Loader` itself does not use CSS variables. The fade animation relies on Tailwind opacity utilities and the SVG ring animation is defined in `src/css/loader.css`:
+
+| Class | Animation |
+|---|---|
+| `animate-spin-slow` | 360° rotation, 2.2 s, linear, infinite |
+
+## Usage
+
+```jsx
+import { Loader } from 'thecore-auth';
+import MyLogo from './assets/MyLogo.svg?react';
+
+// Place once at the root of your app, inside LoadingProvider
+function App({ children }) {
+  return (
+    <LoadingProvider>
+      <Loader
+        Logo={MyLogo}
+        spinnerColor="#6366f1"
+        containerSize="h-[300px] w-[300px]"
+        moreGradients={[
+          'bg-gradient-to-br from-indigo-500 via-purple-400 to-pink-300',
+        ]}
+      />
+      {children}
+    </LoadingProvider>
+  );
+}
+```
+
+### Replace the entire logo area
+
+```jsx
+function CustomSpinner() {
+  return <div className="h-20 w-20 rounded-full border-4 border-white animate-spin" />;
+}
+
+<Loader NewLogoLoader={CustomSpinner} />
+```
+
+### Extend the gradient palette
+
+```jsx
+<Loader
+  moreGradients={[
+    'bg-gradient-to-br from-rose-400 via-orange-300 to-yellow-200',
+    'bg-gradient-to-br from-teal-300 via-cyan-400 to-sky-500',
+  ]}
+  Logo={MyLogo}
+/>
+```
+
+## Notes
+
+- The gradient is chosen randomly at mount time using `Math.random()` — each page refresh may display a different gradient.
+- The fade-out duration (300 ms) is hardcoded; adjust via `overlayStyle` if you need a different transition length.
+- `Loader` is designed for the initial authentication/login loading flow. For in-page spinners, use `Loading` or `LoadingComponent` instead.
+- `customLoginTimeout` from `ConfigContext` is listed as an effect dependency to allow the host app to reset the loader cycle; it does not directly control the timeout.

--- a/docs/components/Loading.md
+++ b/docs/components/Loading.md
@@ -1,0 +1,72 @@
+# Loading
+
+> [Versione italiana](../../docs/it/components/Loading.md) | [Versión española](../../docs/es/components/Loading.md)
+
+## Overview
+
+`Loading` is a full-screen overlay spinner that appears whenever `isLoading` is `true` in `LoadingContext`. It accepts no props; all configuration comes from `loadingProps` and `loadingComponent` exposed by `useLoading()`. When `loadingComponent` is set, it is rendered instead of the default spinner.
+
+## Import
+
+```js
+import { Loading } from 'thecore-auth';
+```
+
+## Props
+
+This component accepts **no props**. All configuration is provided through `LoadingContext`.
+
+| Context value | Type | Default | Description |
+|---|---|---|---|
+| `loadingProps.spinner` | `boolean` | `true` | Whether to render the spinner icon |
+| `loadingProps.spinnerStyle` | `string` | `undefined` | Extra Tailwind classes appended to the spinner |
+| `loadingProps.text` | `string` | `'Loading...'` | Text shown in the center of the overlay |
+| `loadingProps.textStyle` | `string` | `undefined` | Extra Tailwind classes appended to the text element |
+| `loadingProps.children` | `ReactNode` | `undefined` | Custom node rendered instead of the text |
+| `loadingProps.containerStyle` | `string` | `undefined` | Extra Tailwind classes appended to the overlay container |
+| `loadingProps.overrideStyle` | `object` | `{}` | Per-slot class overrides: `container`, `spinner`, `text` |
+| `loadingComponent` | `ReactNode` | `undefined` | When set, replaces the entire default UI |
+
+## CSS Variables
+
+| Variable | Default | Description |
+|---|---|---|
+| `--color-loading-bg` | `#4B556366` | Background color of the fullscreen overlay |
+| `--color-spinner` | `#fff` | Color of the spinner icon |
+
+## Usage
+
+```jsx
+import { LoadingProvider, useLoading, Loading } from 'thecore-auth';
+
+function App({ children }) {
+  return (
+    <LoadingProvider>
+      <AppContent>{children}</AppContent>
+      {/* Loading overlay sits at root level so it covers everything */}
+      <Loading />
+    </LoadingProvider>
+  );
+}
+
+// Trigger loading from anywhere inside the tree
+function DataFetcher() {
+  const { setIsLoading, setLoadingProps } = useLoading();
+
+  async function fetchData() {
+    setLoadingProps({ text: 'Fetching data…', spinner: true });
+    setIsLoading(true);
+    await api.getData();
+    setIsLoading(false);
+  }
+
+  return <button onClick={fetchData}>Load</button>;
+}
+```
+
+## Notes
+
+- `overrideStyle` slot keys: `container`, `spinner`, `text`. When a key is set, the entire default class string for that slot is replaced.
+- Extra classes passed via `spinnerStyle`, `textStyle`, and `containerStyle` are **appended** to the defaults, whereas `overrideStyle` **replaces** them.
+- `loadingComponent` takes precedence over all other configuration: when it is a non-null ReactNode, the spinner and text are never rendered.
+- Place `<Loading />` at the root of your component tree so the fixed overlay covers the full viewport.

--- a/docs/components/LoadingComponent.md
+++ b/docs/components/LoadingComponent.md
@@ -1,0 +1,79 @@
+# LoadingComponent
+
+> [Versione italiana](../../docs/it/components/LoadingComponent.md) | [Versión española](../../docs/es/components/LoadingComponent.md)
+
+## Overview
+
+`LoadingComponent` is a self-contained inline spinner. Unlike `Loading`, it is **not** connected to any context — it accepts all its configuration via props and fits inside any container. Use it to indicate loading state for a specific section of the page rather than the entire viewport.
+
+## Import
+
+```js
+import { LoadingComponent } from 'thecore-auth';
+```
+
+## Props
+
+| Name | Type | Default | Required | Description |
+|---|---|---|---|---|
+| `spinner` | `boolean` | `true` | No | Whether to render the spinner icon |
+| `spinnerStyle` | `string` | `undefined` | No | Extra Tailwind classes appended to the spinner element |
+| `text` | `string` | `'Loading...'` | No | Text shown over the spinner |
+| `textStyle` | `string` | `undefined` | No | Extra Tailwind classes appended to the text element |
+| `children` | `ReactNode` | `undefined` | No | Custom node rendered instead of the default text |
+| `containerStyle` | `string` | `undefined` | No | Extra Tailwind classes appended to the wrapper div |
+| `overrideStyle` | `object` | `{}` | No | Per-slot class overrides: `container`, `spinner`, `text` |
+
+## CSS Variables
+
+`LoadingComponent` does not consume any CSS custom properties. Its defaults are hardcoded Tailwind classes (`text-black`, `animate-spin`).
+
+## Usage
+
+```jsx
+import { LoadingComponent } from 'thecore-auth';
+
+function UserCard({ isLoading, user }) {
+  if (isLoading) {
+    return (
+      // The component fills its parent, so give the parent a known size
+      <div className="h-40 w-full">
+        <LoadingComponent
+          text="Loading profile…"
+          textStyle="text-sm text-gray-500"
+          spinnerStyle="text-indigo-500"
+        />
+      </div>
+    );
+  }
+
+  return <p>{user.name}</p>;
+}
+```
+
+### Custom content via `children`
+
+```jsx
+<LoadingComponent spinner={false}>
+  <span className="text-xs text-gray-400 italic">Please wait…</span>
+</LoadingComponent>
+```
+
+### Full override
+
+```jsx
+<LoadingComponent
+  overrideStyle={{
+    container: 'flex flex-col items-center gap-2 p-4',
+    spinner: 'text-4xl text-blue-600 animate-spin',
+    text: 'text-blue-600 text-sm mt-1',
+  }}
+  text="Syncing…"
+/>
+```
+
+## Notes
+
+- The container is `w-full h-full relative`, so its size is determined entirely by the parent element.
+- `overrideStyle` replaces the full default class string for a slot; `spinnerStyle`, `textStyle`, and `containerStyle` append to defaults.
+- When `children` is provided it replaces the `<p>` text element, but the spinner is still rendered unless `spinner={false}`.

--- a/docs/components/LoginForm.md
+++ b/docs/components/LoginForm.md
@@ -1,0 +1,88 @@
+# LoginForm
+
+> [Versione italiana](../../docs/it/components/LoginForm.md) | [Versión española](../../docs/es/components/LoginForm.md)
+
+## Overview
+
+`LoginForm` is the credential form rendered inside the login card. It has no props: all its state (title, labels, field types, placeholder, button text, style overrides) is consumed from `LoginFormContext` via `useLoginForm()`. Customize the form by calling the setters exposed by the context before rendering.
+
+## Import
+
+```js
+import { LoginForm } from 'thecore-auth';
+```
+
+## Props
+
+This component accepts **no props**. All configuration is handled through `LoginFormContext`.
+
+| Context value | Type | Default | Description |
+|---|---|---|---|
+| `title` | `string` | `'Accedi'` | Heading displayed above the email field |
+| `label` | `string` | `'Email'` | Label text for the email input |
+| `type` | `string` | `'email'` | Input type for the email field |
+| `placeholder` | `string` | `'example@example.it'` | Placeholder for the email input |
+| `buttonText` | `string` | `'Accedi'` | Text displayed in the submit button |
+| `overrideStyle` | `object` | `{}` | Per-slot class overrides (see Notes) |
+
+## CSS Variables
+
+These variables, defined in `src/css/index.css`, control the visual appearance of the form:
+
+| Variable | Default | Description |
+|---|---|---|
+| `--basis-form` | `50%` | Flex-basis of the form element |
+| `--input-form-width` | `70%` | Width of each input container |
+| `--text-form-title-size` | `2.25rem` | Font size of the form title |
+| `--margin-form-title` | `32px 0` | Margin around the form title |
+| `--title-display` | `none` | Whether the title is visible (`block` to show) |
+| `--title-position` | `center` | Text alignment of the title |
+| `--justify-primary` | `center` | Justify-content for the button row |
+| `--padding-primary-button` | `8px 16px` | Padding of the submit button |
+| `--radius-primary-button` | `calc(infinity * 1px)` | Border radius of the submit button |
+| `--color-primary` | `#f56907` | Button background color |
+| `--color-primary-hover` | `#f88b29` | Button hover background color |
+| `--color-primary-text` | `#fff` | Button text color |
+| `--shadow-primary` | `…` | Button box-shadow |
+| `--shadow-primary-hover` | `…` | Button box-shadow on hover |
+| `--shadow-primary-active` | `…` | Button box-shadow on press |
+| `--padding-input` | `10px` | Vertical padding of each input field |
+| `--input-radius` | `8px` | Border radius of each input field |
+
+## Usage
+
+```jsx
+import { LoginFormProvider, useLoginForm, LoginForm } from 'thecore-auth';
+
+// Inner component that configures the form before it mounts
+function ConfiguredForm() {
+  const { setTitle, setLabel, setButtonText, setOverrideStyle } = useLoginForm();
+
+  useEffect(() => {
+    setTitle('Sign in');
+    setLabel('Work email');
+    setButtonText('Log in');
+    // Override the button slot with a custom Tailwind class
+    setOverrideStyle({
+      button: 'bg-indigo-600 hover:bg-indigo-700 text-white px-6 py-2 rounded-full',
+    });
+  }, []);
+
+  return <LoginForm />;
+}
+
+// Wrap the consumer with the provider
+export default function LoginPage() {
+  return (
+    <LoginFormProvider>
+      <ConfiguredForm />
+    </LoginFormProvider>
+  );
+}
+```
+
+## Notes
+
+- `overrideStyle` accepts the following slot keys: `form`, `title`, `containerEmail`, `containerPassword`, `containerButton`, `button`. When a slot key is set, the entire default class string for that slot is replaced (not merged).
+- The component is typically used inside the `Login` or `SmartLogin` page, which already wraps it in `LoginFormProvider`.
+- The password field is always of type `password` and is not configurable via context.

--- a/docs/components/LogoLoader.md
+++ b/docs/components/LogoLoader.md
@@ -1,0 +1,69 @@
+# LogoLoader
+
+> [Versione italiana](../../docs/it/components/LogoLoader.md) | [Versión española](../../docs/es/components/LogoLoader.md)
+
+## Overview
+
+`LogoLoader` renders a circular SVG spinner ring around a logo image. It is used internally by `Loader`, but can be used standalone whenever a logo-plus-ring animation is needed. The ring rotates with a slow 2.2-second spin defined in `src/css/loader.css`.
+
+## Import
+
+```js
+import { LogoLoader } from 'thecore-auth';
+```
+
+## Props
+
+| Name | Type | Default | Required | Description |
+|---|---|---|---|---|
+| `sizeContainer` | `string` | `'h-60 w-60'` | No | Tailwind size classes for the outer container |
+| `Logo` | `ComponentType` | `undefined` | No | React component (typically an SVG) rendered as the centered logo. Must accept a `className` prop |
+| `spinnerColor` | `string` | `'#60A5FA'` | No | CSS color value for the SVG ring stroke |
+
+## CSS Variables
+
+`LogoLoader` does not consume CSS custom properties. The spin animation is defined in `src/css/loader.css`:
+
+| Class | Animation |
+|---|---|
+| `animate-spin-slow` | 360° rotation, 2.2 s, linear, infinite |
+
+## Usage
+
+```jsx
+import { LogoLoader } from 'thecore-auth';
+import MyLogo from './assets/MyLogo.svg?react';
+
+// Standalone usage with a custom size and color
+function SplashScreen() {
+  return (
+    <div className="flex items-center justify-center h-screen bg-indigo-50">
+      <LogoLoader
+        Logo={MyLogo}
+        sizeContainer="h-[200px] w-[200px]"
+        spinnerColor="#6366f1"
+      />
+    </div>
+  );
+}
+```
+
+### Default size with logo
+
+```jsx
+<LogoLoader Logo={MyLogo} />
+```
+
+### No logo (ring only)
+
+```jsx
+// Logo prop is optional — render just the spinning ring
+<LogoLoader sizeContainer="h-20 w-20" spinnerColor="#f43f5e" />
+```
+
+## Notes
+
+- The SVG ring uses `strokeDasharray="280"` and `strokeDashoffset="210"` to render an arc rather than a full circle.
+- The `Logo` component is rendered inside a `<figure>` with `rounded-full overflow-hidden`, so rectangular logos will be cropped to a circle.
+- Import `loader.css` (or ensure the host app imports `thecore-auth`'s CSS bundle) for the `animate-spin-slow` class to take effect.
+- When used inside `Loader`, the `sizeContainer` is controlled by `Loader`'s `containerSize` prop.

--- a/docs/es/components/Alert.md
+++ b/docs/es/components/Alert.md
@@ -1,0 +1,99 @@
+# Alert
+
+> [English](../../../docs/components/Alert.md) | [Versione italiana](../../../docs/it/components/Alert.md)
+
+## Descripción general
+
+`Alert` es un banner de notificación de posición fija estilo toast. Lee su estado de `AlertContext` y `ConfigContext`, por lo que no acepta props. El banner incluye una barra de progreso que se agota en `alertTimeout` milisegundos, después de lo cual se cierra automáticamente. En dispositivos móviles/tabletas con Sileo habilitado, el alert es reemplazado por un toast nativo (ver Notas).
+
+## Importación
+
+```js
+import { Alert } from 'thecore-auth';
+```
+
+## Props
+
+Este componente **no acepta props**. Actívalo llamando a `activeAlert` desde `useAlert()`.
+
+| Valor de `useAlert()` | Tipo | Firma | Descripción |
+|---|---|---|---|
+| `activeAlert` | `function` | `(type, message, customType?)` | Mostrar el alert |
+| `closeAlert` | `function` | `()` | Cerrar el alert inmediatamente |
+| `showAlert` | `boolean` | — | Si el alert está actualmente visible |
+
+**Tipos de alert** (argumento `type` de `activeAlert`):
+
+| Valor | Significado |
+|---|---|
+| `'danger'` | Error / acción destructiva |
+| `'info'` | Información neutral |
+| `'success'` | Operación exitosa |
+| `'warning'` | Advertencia no crítica |
+
+## Variables CSS
+
+| Variable | Por defecto | Descripción |
+|---|---|---|
+| `--color-danger` | `#FEE2E2` | Fondo danger |
+| `--color-danger-text` | `#B91C1C` | Color de texto danger |
+| `--color-danger-hover` | `#FECACA` | Hover botón cerrar danger |
+| `--color-danger-progress` | `#F87171` | Barra de progreso danger |
+| `--color-info` | `#EFF6FF` | Fondo info |
+| `--color-info-text` | `#1D4ED8` | Color de texto info |
+| `--color-info-hover` | `#BFDBFE` | Hover botón cerrar info |
+| `--color-info-progress` | `#60A5FA` | Barra de progreso info |
+| `--color-success` | `#ECFDF5` | Fondo success |
+| `--color-success-text` | `#15803D` | Color de texto success |
+| `--color-success-hover` | `#A7F3D0` | Hover botón cerrar success |
+| `--color-success-progress` | `#34D399` | Barra de progreso success |
+| `--color-warning` | `#F9FAEB` | Fondo warning |
+| `--color-warning-text` | `#D97706` | Color de texto warning |
+| `--color-warning-hover` | `#FDE047` | Hover botón cerrar warning |
+| `--color-warning-progress` | `#FACC15` | Barra de progreso warning |
+
+## Uso
+
+```jsx
+import { AlertProvider, useAlert, Alert } from 'thecore-auth';
+
+// Coloca <Alert /> una vez en la raíz de la app
+function App({ children }) {
+  return (
+    <AlertProvider>
+      {children}
+      <Alert />
+    </AlertProvider>
+  );
+}
+
+// Activa desde cualquier componente del árbol
+function SaveButton() {
+  const { activeAlert } = useAlert();
+
+  async function handleSave() {
+    try {
+      await api.save();
+      activeAlert('success', 'Registro guardado correctamente.');
+    } catch (err) {
+      activeAlert('danger', 'Error al guardar. Por favor, inténtalo de nuevo.');
+    }
+  }
+
+  return <button onClick={handleSave}>Guardar</button>;
+}
+```
+
+### Forzar alert web en móvil
+
+```jsx
+// Pasa un customType no nulo para omitir el toast Sileo incluso en móvil
+activeAlert('warning', 'La sesión está a punto de expirar.', 'web');
+```
+
+## Notas
+
+- La duración `alertTimeout` (en milisegundos) se configura en `ConfigContext` a través de `public/config.json`. La barra de progreso se agota linealmente durante esa duración.
+- Cuando `sileoToastEnabled` es `true` en la configuración y el tipo de dispositivo es `mobile` o `tablet`, `activeAlert` delega a los toasts nativos de Sileo y `<Alert />` nunca se muestra. Pasa un argumento `customType` no nulo para forzar el banner web independientemente del dispositivo.
+- Coloca `<Alert />` en la raíz del árbol de componentes para asegurar que el overlay fijo se superponga sobre todo el contenido.
+- El componente usa `role="alert"` para la accesibilidad.

--- a/docs/es/components/Loader.md
+++ b/docs/es/components/Loader.md
@@ -1,0 +1,86 @@
+# Loader
+
+> [English](../../../docs/components/Loader.md) | [Versione italiana](../../../docs/it/components/Loader.md)
+
+## Descripción general
+
+`Loader` es un overlay animado a pantalla completa mostrado durante la carga inicial de la app. Lee `isLoading` de `LoadingContext` y `customLoginTimeout` de `ConfigContext`. El overlay aparece con fade-in al inicio de la carga y desaparece con fade-out (300 ms) al finalizar. En cada montaje se elige un gradiente aleatorio de una paleta predefinida; la paleta puede reemplazarse o extenderse a través de props.
+
+## Importación
+
+```js
+import { Loader } from 'thecore-auth';
+```
+
+## Props
+
+| Nombre | Tipo | Por defecto | Requerido | Descripción |
+|---|---|---|---|---|
+| `gradients` | `string[]` | `undefined` | No | Reemplaza toda la lista de gradientes predefinida. Si se omite, se usa la paleta por defecto (más `moreGradients`) |
+| `moreGradients` | `string[]` | `undefined` | No | Clases de gradiente Tailwind adicionales añadidas a la lista predefinida |
+| `containerSize` | `string` | `'h-[420px] w-[420px]'` | No | Clases de tamaño Tailwind pasadas al contenedor interno de `LogoLoader` |
+| `overlayStyle` | `string` | `undefined` | No | Reemplaza las clases de posicionamiento predeterminadas del overlay (`fixed top-0 … flex items-center justify-center z-999 transition-opacity duration-300`) |
+| `NewLogoLoader` | `ComponentType` | `undefined` | No | Componente personalizado renderizado en lugar de `LogoLoader` |
+| `Logo` | `ComponentType` | `undefined` | No | Componente SVG/imagen pasado a `LogoLoader` como logo central |
+| `spinnerColor` | `string` | `'#60A5FA'` | No | Color del trazo del anillo SVG en `LogoLoader` |
+
+## Variables CSS
+
+`Loader` no usa variables CSS. La animación de fade se basa en las utilidades de opacidad de Tailwind y la animación del anillo SVG está definida en `src/css/loader.css`:
+
+| Clase | Animación |
+|---|---|
+| `animate-spin-slow` | Rotación 360°, 2.2 s, lineal, infinita |
+
+## Uso
+
+```jsx
+import { Loader } from 'thecore-auth';
+import MyLogo from './assets/MyLogo.svg?react';
+
+// Coloca una vez en la raíz de la app, dentro de LoadingProvider
+function App({ children }) {
+  return (
+    <LoadingProvider>
+      <Loader
+        Logo={MyLogo}
+        spinnerColor="#6366f1"
+        containerSize="h-[300px] w-[300px]"
+        moreGradients={[
+          'bg-gradient-to-br from-indigo-500 via-purple-400 to-pink-300',
+        ]}
+      />
+      {children}
+    </LoadingProvider>
+  );
+}
+```
+
+### Reemplazar toda el área del logo
+
+```jsx
+function CustomSpinner() {
+  return <div className="h-20 w-20 rounded-full border-4 border-white animate-spin" />;
+}
+
+<Loader NewLogoLoader={CustomSpinner} />
+```
+
+### Extender la paleta de gradientes
+
+```jsx
+<Loader
+  moreGradients={[
+    'bg-gradient-to-br from-rose-400 via-orange-300 to-yellow-200',
+    'bg-gradient-to-br from-teal-300 via-cyan-400 to-sky-500',
+  ]}
+  Logo={MyLogo}
+/>
+```
+
+## Notas
+
+- El gradiente se elige aleatoriamente al montar usando `Math.random()` — cada recarga de página puede mostrar un gradiente diferente.
+- La duración del fade-out (300 ms) está hardcoded; ajústala a través de `overlayStyle` si necesitas una transición diferente.
+- `Loader` está diseñado para el flujo de carga inicial de autenticación/login. Para spinners en-página usa `Loading` o `LoadingComponent`.
+- `customLoginTimeout` de `ConfigContext` está listado como dependencia del effect para permitir que la app host resetee el ciclo del loader; no controla directamente el timeout.

--- a/docs/es/components/Loading.md
+++ b/docs/es/components/Loading.md
@@ -1,0 +1,72 @@
+# Loading
+
+> [English](../../../docs/components/Loading.md) | [Versione italiana](../../../docs/it/components/Loading.md)
+
+## Descripción general
+
+`Loading` es un overlay spinner a pantalla completa que aparece cada vez que `isLoading` es `true` en `LoadingContext`. No acepta props; toda la configuración proviene de `loadingProps` y `loadingComponent` expuestos por `useLoading()`. Cuando `loadingComponent` está definido, se renderiza en lugar del spinner predeterminado.
+
+## Importación
+
+```js
+import { Loading } from 'thecore-auth';
+```
+
+## Props
+
+Este componente **no acepta props**. Toda la configuración se gestiona a través de `LoadingContext`.
+
+| Valor del context | Tipo | Por defecto | Descripción |
+|---|---|---|---|
+| `loadingProps.spinner` | `boolean` | `true` | Si renderizar el ícono spinner |
+| `loadingProps.spinnerStyle` | `string` | `undefined` | Clases Tailwind adicionales añadidas al spinner |
+| `loadingProps.text` | `string` | `'Loading...'` | Texto mostrado en el centro del overlay |
+| `loadingProps.textStyle` | `string` | `undefined` | Clases Tailwind adicionales añadidas al elemento texto |
+| `loadingProps.children` | `ReactNode` | `undefined` | Nodo personalizado renderizado en lugar del texto |
+| `loadingProps.containerStyle` | `string` | `undefined` | Clases Tailwind adicionales añadidas al contenedor overlay |
+| `loadingProps.overrideStyle` | `object` | `{}` | Anulaciones de clases por slot: `container`, `spinner`, `text` |
+| `loadingComponent` | `ReactNode` | `undefined` | Cuando está definido, reemplaza toda la UI predeterminada |
+
+## Variables CSS
+
+| Variable | Por defecto | Descripción |
+|---|---|---|
+| `--color-loading-bg` | `#4B556366` | Color de fondo del overlay a pantalla completa |
+| `--color-spinner` | `#fff` | Color del ícono spinner |
+
+## Uso
+
+```jsx
+import { LoadingProvider, useLoading, Loading } from 'thecore-auth';
+
+// <Loading /> se coloca a nivel raíz para cubrir todo
+function App({ children }) {
+  return (
+    <LoadingProvider>
+      <AppContent>{children}</AppContent>
+      <Loading />
+    </LoadingProvider>
+  );
+}
+
+// Activa el loading desde cualquier componente del árbol
+function DataFetcher() {
+  const { setIsLoading, setLoadingProps } = useLoading();
+
+  async function fetchData() {
+    setLoadingProps({ text: 'Obteniendo datos…', spinner: true });
+    setIsLoading(true);
+    await api.getData();
+    setIsLoading(false);
+  }
+
+  return <button onClick={fetchData}>Cargar</button>;
+}
+```
+
+## Notas
+
+- Las claves de slot de `overrideStyle` son: `container`, `spinner`, `text`. Cuando se establece una clave, se reemplaza toda la cadena de clases predeterminada para ese slot.
+- Las clases extra pasadas a través de `spinnerStyle`, `textStyle` y `containerStyle` se **añaden** a los valores predeterminados, mientras que `overrideStyle` los **reemplaza**.
+- `loadingComponent` tiene precedencia sobre toda la configuración: cuando es un ReactNode no nulo, el spinner y el texto nunca se renderizan.
+- Coloca `<Loading />` en la raíz del árbol de componentes para garantizar que el overlay fijo cubra todo el viewport.

--- a/docs/es/components/LoadingComponent.md
+++ b/docs/es/components/LoadingComponent.md
@@ -1,0 +1,79 @@
+# LoadingComponent
+
+> [English](../../../docs/components/LoadingComponent.md) | [Versione italiana](../../../docs/it/components/LoadingComponent.md)
+
+## Descripción general
+
+`LoadingComponent` es un spinner inline autónomo. A diferencia de `Loading`, **no** está conectado a ningún context — recibe toda su configuración a través de props y se adapta a cualquier contenedor. Úsalo para indicar el estado de carga de una sección específica de la página, en lugar de todo el viewport.
+
+## Importación
+
+```js
+import { LoadingComponent } from 'thecore-auth';
+```
+
+## Props
+
+| Nombre | Tipo | Por defecto | Requerido | Descripción |
+|---|---|---|---|---|
+| `spinner` | `boolean` | `true` | No | Si renderizar el ícono spinner |
+| `spinnerStyle` | `string` | `undefined` | No | Clases Tailwind adicionales añadidas al spinner |
+| `text` | `string` | `'Loading...'` | No | Texto mostrado sobre el spinner |
+| `textStyle` | `string` | `undefined` | No | Clases Tailwind adicionales añadidas al elemento texto |
+| `children` | `ReactNode` | `undefined` | No | Nodo personalizado renderizado en lugar del texto predeterminado |
+| `containerStyle` | `string` | `undefined` | No | Clases Tailwind adicionales añadidas al div contenedor |
+| `overrideStyle` | `object` | `{}` | No | Anulaciones de clases por slot: `container`, `spinner`, `text` |
+
+## Variables CSS
+
+`LoadingComponent` no usa propiedades CSS personalizadas. Sus valores predeterminados son clases Tailwind hardcoded (`text-black`, `animate-spin`).
+
+## Uso
+
+```jsx
+import { LoadingComponent } from 'thecore-auth';
+
+function UserCard({ isLoading, user }) {
+  if (isLoading) {
+    return (
+      // El componente rellena su padre, así que dale una dimensión conocida al padre
+      <div className="h-40 w-full">
+        <LoadingComponent
+          text="Cargando perfil…"
+          textStyle="text-sm text-gray-500"
+          spinnerStyle="text-indigo-500"
+        />
+      </div>
+    );
+  }
+
+  return <p>{user.name}</p>;
+}
+```
+
+### Contenido personalizado vía `children`
+
+```jsx
+<LoadingComponent spinner={false}>
+  <span className="text-xs text-gray-400 italic">Por favor, espere…</span>
+</LoadingComponent>
+```
+
+### Anulación completa
+
+```jsx
+<LoadingComponent
+  overrideStyle={{
+    container: 'flex flex-col items-center gap-2 p-4',
+    spinner: 'text-4xl text-blue-600 animate-spin',
+    text: 'text-blue-600 text-sm mt-1',
+  }}
+  text="Sincronizando…"
+/>
+```
+
+## Notas
+
+- El contenedor es `w-full h-full relative`, por lo que su tamaño está determinado enteramente por el elemento padre.
+- `overrideStyle` reemplaza toda la cadena de clases predeterminada para un slot; `spinnerStyle`, `textStyle` y `containerStyle` se añaden a los valores predeterminados.
+- Cuando se proporciona `children`, reemplaza el elemento texto `<p>`, pero el spinner sigue renderizándose a menos que `spinner={false}`.

--- a/docs/es/components/LoginForm.md
+++ b/docs/es/components/LoginForm.md
@@ -1,0 +1,88 @@
+# LoginForm
+
+> [English](../../../docs/components/LoginForm.md) | [Versione italiana](../../../docs/it/components/LoginForm.md)
+
+## Descripción general
+
+`LoginForm` es el formulario de credenciales renderizado dentro de la tarjeta de login. No acepta props: todo su estado (título, etiquetas, tipo de campos, placeholder, texto del botón, anulaciones de estilo) se lee de `LoginFormContext` a través de `useLoginForm()`. Para personalizar el formulario, llama a los setters expuestos por el context antes del render.
+
+## Importación
+
+```js
+import { LoginForm } from 'thecore-auth';
+```
+
+## Props
+
+Este componente **no acepta props**. Toda la configuración se gestiona a través de `LoginFormContext`.
+
+| Valor del context | Tipo | Por defecto | Descripción |
+|---|---|---|---|
+| `title` | `string` | `'Accedi'` | Encabezado mostrado sobre el campo email |
+| `label` | `string` | `'Email'` | Texto de la etiqueta para el campo email |
+| `type` | `string` | `'email'` | Tipo de input para el campo email |
+| `placeholder` | `string` | `'example@example.it'` | Placeholder del input email |
+| `buttonText` | `string` | `'Accedi'` | Texto del botón de envío |
+| `overrideStyle` | `object` | `{}` | Anulaciones de clases por slot (ver Notas) |
+
+## Variables CSS
+
+Estas variables, definidas en `src/css/index.css`, controlan el aspecto visual del formulario:
+
+| Variable | Por defecto | Descripción |
+|---|---|---|
+| `--basis-form` | `50%` | Flex-basis del elemento form |
+| `--input-form-width` | `70%` | Ancho de cada contenedor de input |
+| `--text-form-title-size` | `2.25rem` | Tamaño de fuente del título del formulario |
+| `--margin-form-title` | `32px 0` | Margen alrededor del título del formulario |
+| `--title-display` | `none` | Visibilidad del título (`block` para mostrarlo) |
+| `--title-position` | `center` | Alineación del texto del título |
+| `--justify-primary` | `center` | Justify-content de la fila del botón |
+| `--padding-primary-button` | `8px 16px` | Padding del botón de envío |
+| `--radius-primary-button` | `calc(infinity * 1px)` | Border radius del botón de envío |
+| `--color-primary` | `#f56907` | Color de fondo del botón |
+| `--color-primary-hover` | `#f88b29` | Color de fondo del botón al pasar el ratón |
+| `--color-primary-text` | `#fff` | Color del texto del botón |
+| `--shadow-primary` | `…` | Box-shadow del botón |
+| `--shadow-primary-hover` | `…` | Box-shadow del botón al pasar el ratón |
+| `--shadow-primary-active` | `…` | Box-shadow del botón al presionar |
+| `--padding-input` | `10px` | Padding vertical de cada campo input |
+| `--input-radius` | `8px` | Border radius de cada campo input |
+
+## Uso
+
+```jsx
+import { LoginFormProvider, useLoginForm, LoginForm } from 'thecore-auth';
+
+// Componente interno que configura el formulario antes del montaje
+function ConfiguredForm() {
+  const { setTitle, setLabel, setButtonText, setOverrideStyle } = useLoginForm();
+
+  useEffect(() => {
+    setTitle('Iniciar sesión');
+    setLabel('Correo corporativo');
+    setButtonText('Entrar');
+    // Anular el slot botón con una clase Tailwind personalizada
+    setOverrideStyle({
+      button: 'bg-indigo-600 hover:bg-indigo-700 text-white px-6 py-2 rounded-full',
+    });
+  }, []);
+
+  return <LoginForm />;
+}
+
+// Envuelve el consumidor con el proveedor
+export default function LoginPage() {
+  return (
+    <LoginFormProvider>
+      <ConfiguredForm />
+    </LoginFormProvider>
+  );
+}
+```
+
+## Notas
+
+- `overrideStyle` acepta las siguientes claves de slot: `form`, `title`, `containerEmail`, `containerPassword`, `containerButton`, `button`. Cuando se establece una clave de slot, se reemplaza toda la cadena de clases predeterminada para ese slot (no se fusiona).
+- El componente se usa típicamente dentro de las páginas `Login` o `SmartLogin`, que ya lo envuelven en `LoginFormProvider`.
+- El campo de contraseña es siempre de tipo `password` y no es configurable a través del context.

--- a/docs/es/components/LogoLoader.md
+++ b/docs/es/components/LogoLoader.md
@@ -1,0 +1,69 @@
+# LogoLoader
+
+> [English](../../../docs/components/LogoLoader.md) | [Versione italiana](../../../docs/it/components/LogoLoader.md)
+
+## Descripción general
+
+`LogoLoader` renderiza un anillo SVG circular giratorio alrededor de una imagen de logo. Se usa internamente por `Loader`, pero puede usarse de forma independiente cuando se necesita una animación de logo-con-anillo. El anillo gira con una rotación lenta de 2.2 segundos definida en `src/css/loader.css`.
+
+## Importación
+
+```js
+import { LogoLoader } from 'thecore-auth';
+```
+
+## Props
+
+| Nombre | Tipo | Por defecto | Requerido | Descripción |
+|---|---|---|---|---|
+| `sizeContainer` | `string` | `'h-60 w-60'` | No | Clases de tamaño Tailwind para el contenedor exterior |
+| `Logo` | `ComponentType` | `undefined` | No | Componente React (típicamente un SVG) renderizado como logo central. Debe aceptar una prop `className` |
+| `spinnerColor` | `string` | `'#60A5FA'` | No | Valor CSS del color para el trazo del anillo SVG |
+
+## Variables CSS
+
+`LogoLoader` no usa propiedades CSS personalizadas. La animación de rotación está definida en `src/css/loader.css`:
+
+| Clase | Animación |
+|---|---|
+| `animate-spin-slow` | Rotación 360°, 2.2 s, lineal, infinita |
+
+## Uso
+
+```jsx
+import { LogoLoader } from 'thecore-auth';
+import MyLogo from './assets/MyLogo.svg?react';
+
+// Uso independiente con tamaño y color personalizados
+function SplashScreen() {
+  return (
+    <div className="flex items-center justify-center h-screen bg-indigo-50">
+      <LogoLoader
+        Logo={MyLogo}
+        sizeContainer="h-[200px] w-[200px]"
+        spinnerColor="#6366f1"
+      />
+    </div>
+  );
+}
+```
+
+### Tamaño predeterminado con logo
+
+```jsx
+<LogoLoader Logo={MyLogo} />
+```
+
+### Sin logo (solo anillo)
+
+```jsx
+// La prop Logo es opcional — renderiza solo el anillo giratorio
+<LogoLoader sizeContainer="h-20 w-20" spinnerColor="#f43f5e" />
+```
+
+## Notas
+
+- El anillo SVG usa `strokeDasharray="280"` y `strokeDashoffset="210"` para renderizar un arco en lugar de un círculo completo.
+- El componente `Logo` se renderiza dentro de un `<figure>` con `rounded-full overflow-hidden`, por lo que los logos rectangulares serán recortados en forma circular.
+- Importa `loader.css` (o asegúrate de que la app host importe el bundle CSS de `thecore-auth`) para que la clase `animate-spin-slow` tenga efecto.
+- Cuando se usa dentro de `Loader`, `sizeContainer` está controlado por la prop `containerSize` de `Loader`.

--- a/docs/it/components/Alert.md
+++ b/docs/it/components/Alert.md
@@ -1,0 +1,99 @@
+# Alert
+
+> [English](../../../docs/components/Alert.md) | [Versión española](../../../docs/es/components/Alert.md)
+
+## Panoramica
+
+`Alert` è un banner di notifica in stile toast posizionato in modo fisso. Legge il suo stato da `AlertContext` e `ConfigContext`, quindi non accetta props. Il banner include una barra di avanzamento che si esaurisce in `alertTimeout` millisecondi, dopodiché si auto-chiude. Su dispositivi mobile/tablet con Sileo abilitato, l'alert viene sostituito da un toast nativo (vedi Note).
+
+## Import
+
+```js
+import { Alert } from 'thecore-auth';
+```
+
+## Props
+
+Questo componente **non accetta props**. Attivalo chiamando `activeAlert` da `useAlert()`.
+
+| Valore di `useAlert()` | Tipo | Firma | Descrizione |
+|---|---|---|---|
+| `activeAlert` | `function` | `(type, message, customType?)` | Mostra l'alert |
+| `closeAlert` | `function` | `()` | Chiude l'alert immediatamente |
+| `showAlert` | `boolean` | — | Se l'alert è attualmente visibile |
+
+**Tipi di alert** (argomento `type` di `activeAlert`):
+
+| Valore | Significato |
+|---|---|
+| `'danger'` | Errore / azione distruttiva |
+| `'info'` | Informazione neutra |
+| `'success'` | Operazione riuscita |
+| `'warning'` | Avviso non critico |
+
+## Variabili CSS
+
+| Variabile | Default | Descrizione |
+|---|---|---|
+| `--color-danger` | `#FEE2E2` | Sfondo danger |
+| `--color-danger-text` | `#B91C1C` | Colore testo danger |
+| `--color-danger-hover` | `#FECACA` | Hover bottone chiudi danger |
+| `--color-danger-progress` | `#F87171` | Barra progresso danger |
+| `--color-info` | `#EFF6FF` | Sfondo info |
+| `--color-info-text` | `#1D4ED8` | Colore testo info |
+| `--color-info-hover` | `#BFDBFE` | Hover bottone chiudi info |
+| `--color-info-progress` | `#60A5FA` | Barra progresso info |
+| `--color-success` | `#ECFDF5` | Sfondo success |
+| `--color-success-text` | `#15803D` | Colore testo success |
+| `--color-success-hover` | `#A7F3D0` | Hover bottone chiudi success |
+| `--color-success-progress` | `#34D399` | Barra progresso success |
+| `--color-warning` | `#F9FAEB` | Sfondo warning |
+| `--color-warning-text` | `#D97706` | Colore testo warning |
+| `--color-warning-hover` | `#FDE047` | Hover bottone chiudi warning |
+| `--color-warning-progress` | `#FACC15` | Barra progresso warning |
+
+## Utilizzo
+
+```jsx
+import { AlertProvider, useAlert, Alert } from 'thecore-auth';
+
+// Posiziona <Alert /> una volta nella root dell'app
+function App({ children }) {
+  return (
+    <AlertProvider>
+      {children}
+      <Alert />
+    </AlertProvider>
+  );
+}
+
+// Attiva da qualsiasi componente nell'albero
+function SaveButton() {
+  const { activeAlert } = useAlert();
+
+  async function handleSave() {
+    try {
+      await api.save();
+      activeAlert('success', 'Record salvato con successo.');
+    } catch (err) {
+      activeAlert('danger', 'Salvataggio fallito. Riprova.');
+    }
+  }
+
+  return <button onClick={handleSave}>Salva</button>;
+}
+```
+
+### Forza l'alert web su mobile
+
+```jsx
+// Passa un customType non null per bypassare il toast Sileo anche su mobile
+activeAlert('warning', 'Sessione in scadenza.', 'web');
+```
+
+## Note
+
+- La durata `alertTimeout` (in millisecondi) è configurata in `ConfigContext` tramite `public/config.json`. La barra di avanzamento si esaurisce linearmente in quella durata.
+- Quando `sileoToastEnabled` è `true` nel config e il tipo di dispositivo è `mobile` o `tablet`, `activeAlert` delega ai toast nativi Sileo e `<Alert />` non viene mai mostrato. Passa un argomento `customType` non null per forzare il banner web indipendentemente dal dispositivo.
+- Posiziona `<Alert />` nella root del tuo albero di componenti per garantire che l'overlay fisso si sovrapponga a tutto il contenuto.
+- Il componente usa `role="alert"` per l'accessibilità.

--- a/docs/it/components/Loader.md
+++ b/docs/it/components/Loader.md
@@ -1,0 +1,86 @@
+# Loader
+
+> [English](../../../docs/components/Loader.md) | [Versión española](../../../docs/es/components/Loader.md)
+
+## Panoramica
+
+`Loader` è un overlay animato a schermo intero mostrato durante il caricamento iniziale dell'app. Legge `isLoading` da `LoadingContext` e `customLoginTimeout` da `ConfigContext`. L'overlay appare in fade-in all'inizio del caricamento e svanisce in fade-out (300 ms) al termine. Ad ogni mount viene scelto un gradiente casuale da una palette predefinita; la palette può essere sostituita o estesa tramite props.
+
+## Import
+
+```js
+import { Loader } from 'thecore-auth';
+```
+
+## Props
+
+| Nome | Tipo | Default | Obbligatorio | Descrizione |
+|---|---|---|---|---|
+| `gradients` | `string[]` | `undefined` | No | Sostituisce l'intera lista di gradienti predefinita. Se omesso, viene usata la palette di default (più `moreGradients`) |
+| `moreGradients` | `string[]` | `undefined` | No | Classi gradiente Tailwind aggiuntive aggiunte alla lista predefinita |
+| `containerSize` | `string` | `'h-[420px] w-[420px]'` | No | Classi Tailwind di dimensione passate al container interno di `LogoLoader` |
+| `overlayStyle` | `string` | `undefined` | No | Sostituisce le classi di posizionamento predefinite dell'overlay (`fixed top-0 … flex items-center justify-center z-999 transition-opacity duration-300`) |
+| `NewLogoLoader` | `ComponentType` | `undefined` | No | Componente custom renderizzato al posto di `LogoLoader` |
+| `Logo` | `ComponentType` | `undefined` | No | Componente SVG/immagine passato a `LogoLoader` come logo centrale |
+| `spinnerColor` | `string` | `'#60A5FA'` | No | Colore del tratto dell'anello SVG in `LogoLoader` |
+
+## Variabili CSS
+
+`Loader` non usa variabili CSS. L'animazione fade si basa sulle utility Tailwind di opacità e l'animazione dell'anello SVG è definita in `src/css/loader.css`:
+
+| Classe | Animazione |
+|---|---|
+| `animate-spin-slow` | Rotazione 360°, 2.2 s, lineare, infinita |
+
+## Utilizzo
+
+```jsx
+import { Loader } from 'thecore-auth';
+import MyLogo from './assets/MyLogo.svg?react';
+
+// Posiziona una volta nella root dell'app, dentro LoadingProvider
+function App({ children }) {
+  return (
+    <LoadingProvider>
+      <Loader
+        Logo={MyLogo}
+        spinnerColor="#6366f1"
+        containerSize="h-[300px] w-[300px]"
+        moreGradients={[
+          'bg-gradient-to-br from-indigo-500 via-purple-400 to-pink-300',
+        ]}
+      />
+      {children}
+    </LoadingProvider>
+  );
+}
+```
+
+### Sostituire l'intera area logo
+
+```jsx
+function CustomSpinner() {
+  return <div className="h-20 w-20 rounded-full border-4 border-white animate-spin" />;
+}
+
+<Loader NewLogoLoader={CustomSpinner} />
+```
+
+### Estendere la palette dei gradienti
+
+```jsx
+<Loader
+  moreGradients={[
+    'bg-gradient-to-br from-rose-400 via-orange-300 to-yellow-200',
+    'bg-gradient-to-br from-teal-300 via-cyan-400 to-sky-500',
+  ]}
+  Logo={MyLogo}
+/>
+```
+
+## Note
+
+- Il gradiente viene scelto casualmente al mount tramite `Math.random()` — ogni ricarica della pagina può mostrare un gradiente diverso.
+- La durata del fade-out (300 ms) è hardcoded; regolala tramite `overlayStyle` se hai bisogno di una transizione diversa.
+- `Loader` è pensato per il flusso di caricamento iniziale di autenticazione/login. Per spinner in-page usa `Loading` o `LoadingComponent`.
+- `customLoginTimeout` da `ConfigContext` è elencato come dipendenza dell'effect per permettere all'app host di resettare il ciclo del loader; non controlla direttamente il timeout.

--- a/docs/it/components/Loading.md
+++ b/docs/it/components/Loading.md
@@ -1,0 +1,72 @@
+# Loading
+
+> [English](../../../docs/components/Loading.md) | [Versión española](../../../docs/es/components/Loading.md)
+
+## Panoramica
+
+`Loading` è uno spinner overlay a schermo intero che appare ogni volta che `isLoading` è `true` in `LoadingContext`. Non accetta props; tutta la configurazione proviene da `loadingProps` e `loadingComponent` esposti da `useLoading()`. Quando `loadingComponent` è impostato, viene renderizzato al posto dello spinner predefinito.
+
+## Import
+
+```js
+import { Loading } from 'thecore-auth';
+```
+
+## Props
+
+Questo componente **non accetta props**. Tutta la configurazione avviene tramite `LoadingContext`.
+
+| Valore del context | Tipo | Default | Descrizione |
+|---|---|---|---|
+| `loadingProps.spinner` | `boolean` | `true` | Se renderizzare l'icona spinner |
+| `loadingProps.spinnerStyle` | `string` | `undefined` | Classi Tailwind aggiuntive aggiunte allo spinner |
+| `loadingProps.text` | `string` | `'Loading...'` | Testo mostrato al centro dell'overlay |
+| `loadingProps.textStyle` | `string` | `undefined` | Classi Tailwind aggiuntive aggiunte all'elemento testo |
+| `loadingProps.children` | `ReactNode` | `undefined` | Nodo custom renderizzato al posto del testo |
+| `loadingProps.containerStyle` | `string` | `undefined` | Classi Tailwind aggiuntive aggiunte al container overlay |
+| `loadingProps.overrideStyle` | `object` | `{}` | Override delle classi per slot: `container`, `spinner`, `text` |
+| `loadingComponent` | `ReactNode` | `undefined` | Se impostato, sostituisce l'intera UI predefinita |
+
+## Variabili CSS
+
+| Variabile | Default | Descrizione |
+|---|---|---|
+| `--color-loading-bg` | `#4B556366` | Colore di sfondo dell'overlay a schermo intero |
+| `--color-spinner` | `#fff` | Colore dell'icona spinner |
+
+## Utilizzo
+
+```jsx
+import { LoadingProvider, useLoading, Loading } from 'thecore-auth';
+
+// <Loading /> è posizionato a livello root così copre tutto
+function App({ children }) {
+  return (
+    <LoadingProvider>
+      <AppContent>{children}</AppContent>
+      <Loading />
+    </LoadingProvider>
+  );
+}
+
+// Attiva il loading da qualsiasi componente nell'albero
+function DataFetcher() {
+  const { setIsLoading, setLoadingProps } = useLoading();
+
+  async function fetchData() {
+    setLoadingProps({ text: 'Recupero dati…', spinner: true });
+    setIsLoading(true);
+    await api.getData();
+    setIsLoading(false);
+  }
+
+  return <button onClick={fetchData}>Carica</button>;
+}
+```
+
+## Note
+
+- Le chiavi slot di `overrideStyle` sono: `container`, `spinner`, `text`. Quando una chiave è impostata, l'intera stringa di classi predefinita viene sostituita.
+- Le classi extra passate tramite `spinnerStyle`, `textStyle` e `containerStyle` vengono **aggiunte** ai default, mentre `overrideStyle` li **sostituisce**.
+- `loadingComponent` ha precedenza su tutta la configurazione: quando è un ReactNode non null, spinner e testo non vengono mai renderizzati.
+- Posiziona `<Loading />` nella root del tuo albero di componenti per garantire che l'overlay fisso copra l'intero viewport.

--- a/docs/it/components/LoadingComponent.md
+++ b/docs/it/components/LoadingComponent.md
@@ -1,0 +1,79 @@
+# LoadingComponent
+
+> [English](../../../docs/components/LoadingComponent.md) | [Versión española](../../../docs/es/components/LoadingComponent.md)
+
+## Panoramica
+
+`LoadingComponent` è uno spinner inline autonomo. A differenza di `Loading`, **non** è connesso ad alcun context — riceve tutta la configurazione via props e si adatta a qualsiasi container. Usalo per indicare lo stato di caricamento di una sezione specifica della pagina, anziché dell'intero viewport.
+
+## Import
+
+```js
+import { LoadingComponent } from 'thecore-auth';
+```
+
+## Props
+
+| Nome | Tipo | Default | Obbligatorio | Descrizione |
+|---|---|---|---|---|
+| `spinner` | `boolean` | `true` | No | Se renderizzare l'icona spinner |
+| `spinnerStyle` | `string` | `undefined` | No | Classi Tailwind aggiuntive aggiunte allo spinner |
+| `text` | `string` | `'Loading...'` | No | Testo mostrato sopra lo spinner |
+| `textStyle` | `string` | `undefined` | No | Classi Tailwind aggiuntive aggiunte all'elemento testo |
+| `children` | `ReactNode` | `undefined` | No | Nodo custom renderizzato al posto del testo predefinito |
+| `containerStyle` | `string` | `undefined` | No | Classi Tailwind aggiuntive aggiunte al div wrapper |
+| `overrideStyle` | `object` | `{}` | No | Override delle classi per slot: `container`, `spinner`, `text` |
+
+## Variabili CSS
+
+`LoadingComponent` non usa proprietà CSS custom. I suoi default sono classi Tailwind hardcoded (`text-black`, `animate-spin`).
+
+## Utilizzo
+
+```jsx
+import { LoadingComponent } from 'thecore-auth';
+
+function UserCard({ isLoading, user }) {
+  if (isLoading) {
+    return (
+      // Il componente riempie il parent, quindi assegna una dimensione nota al parent
+      <div className="h-40 w-full">
+        <LoadingComponent
+          text="Caricamento profilo…"
+          textStyle="text-sm text-gray-500"
+          spinnerStyle="text-indigo-500"
+        />
+      </div>
+    );
+  }
+
+  return <p>{user.name}</p>;
+}
+```
+
+### Contenuto custom tramite `children`
+
+```jsx
+<LoadingComponent spinner={false}>
+  <span className="text-xs text-gray-400 italic">Attendere prego…</span>
+</LoadingComponent>
+```
+
+### Override completo
+
+```jsx
+<LoadingComponent
+  overrideStyle={{
+    container: 'flex flex-col items-center gap-2 p-4',
+    spinner: 'text-4xl text-blue-600 animate-spin',
+    text: 'text-blue-600 text-sm mt-1',
+  }}
+  text="Sincronizzazione…"
+/>
+```
+
+## Note
+
+- Il container è `w-full h-full relative`, quindi la sua dimensione è determinata interamente dall'elemento parent.
+- `overrideStyle` sostituisce l'intera stringa di classi predefinita per uno slot; `spinnerStyle`, `textStyle` e `containerStyle` si aggiungono ai default.
+- Quando `children` è fornito, sostituisce l'elemento testo `<p>`, ma lo spinner viene comunque renderizzato a meno che `spinner={false}`.

--- a/docs/it/components/LoginForm.md
+++ b/docs/it/components/LoginForm.md
@@ -1,0 +1,88 @@
+# LoginForm
+
+> [English](../../../docs/components/LoginForm.md) | [Versión española](../../../docs/es/components/LoginForm.md)
+
+## Panoramica
+
+`LoginForm` è il form per le credenziali renderizzato all'interno della card di login. Non accetta props: tutto il suo stato (titolo, etichette, tipo dei campi, placeholder, testo del bottone, override degli stili) viene letto da `LoginFormContext` tramite `useLoginForm()`. Per personalizzare il form, chiama i setter esposti dal context prima del render.
+
+## Import
+
+```js
+import { LoginForm } from 'thecore-auth';
+```
+
+## Props
+
+Questo componente **non accetta props**. Tutta la configurazione avviene tramite `LoginFormContext`.
+
+| Valore del context | Tipo | Default | Descrizione |
+|---|---|---|---|
+| `title` | `string` | `'Accedi'` | Intestazione mostrata sopra il campo email |
+| `label` | `string` | `'Email'` | Testo dell'etichetta per il campo email |
+| `type` | `string` | `'email'` | Tipo dell'input per il campo email |
+| `placeholder` | `string` | `'example@example.it'` | Placeholder dell'input email |
+| `buttonText` | `string` | `'Accedi'` | Testo del bottone di submit |
+| `overrideStyle` | `object` | `{}` | Override delle classi per slot (vedi Note) |
+
+## Variabili CSS
+
+Queste variabili, definite in `src/css/index.css`, controllano l'aspetto visivo del form:
+
+| Variabile | Default | Descrizione |
+|---|---|---|
+| `--basis-form` | `50%` | Flex-basis dell'elemento form |
+| `--input-form-width` | `70%` | Larghezza di ogni container input |
+| `--text-form-title-size` | `2.25rem` | Dimensione del titolo del form |
+| `--margin-form-title` | `32px 0` | Margine attorno al titolo del form |
+| `--title-display` | `none` | Visibilità del titolo (`block` per mostrarlo) |
+| `--title-position` | `center` | Allineamento del testo del titolo |
+| `--justify-primary` | `center` | Justify-content della riga del bottone |
+| `--padding-primary-button` | `8px 16px` | Padding del bottone di submit |
+| `--radius-primary-button` | `calc(infinity * 1px)` | Border radius del bottone di submit |
+| `--color-primary` | `#f56907` | Colore di sfondo del bottone |
+| `--color-primary-hover` | `#f88b29` | Colore di sfondo del bottone al hover |
+| `--color-primary-text` | `#fff` | Colore del testo del bottone |
+| `--shadow-primary` | `…` | Box-shadow del bottone |
+| `--shadow-primary-hover` | `…` | Box-shadow del bottone al hover |
+| `--shadow-primary-active` | `…` | Box-shadow del bottone al press |
+| `--padding-input` | `10px` | Padding verticale di ogni campo input |
+| `--input-radius` | `8px` | Border radius di ogni campo input |
+
+## Utilizzo
+
+```jsx
+import { LoginFormProvider, useLoginForm, LoginForm } from 'thecore-auth';
+
+// Componente interno che configura il form prima del mount
+function ConfiguredForm() {
+  const { setTitle, setLabel, setButtonText, setOverrideStyle } = useLoginForm();
+
+  useEffect(() => {
+    setTitle('Accedi');
+    setLabel('Email aziendale');
+    setButtonText('Entra');
+    // Override dello slot bottone con una classe Tailwind custom
+    setOverrideStyle({
+      button: 'bg-indigo-600 hover:bg-indigo-700 text-white px-6 py-2 rounded-full',
+    });
+  }, []);
+
+  return <LoginForm />;
+}
+
+// Avvolgi il consumer con il provider
+export default function LoginPage() {
+  return (
+    <LoginFormProvider>
+      <ConfiguredForm />
+    </LoginFormProvider>
+  );
+}
+```
+
+## Note
+
+- `overrideStyle` accetta le seguenti chiavi slot: `form`, `title`, `containerEmail`, `containerPassword`, `containerButton`, `button`. Quando una chiave è impostata, l'intera stringa di classi predefinita per quello slot viene sostituita (non mergiata).
+- Il componente è tipicamente usato all'interno delle pagine `Login` o `SmartLogin`, che già lo avvolgono in `LoginFormProvider`.
+- Il campo password è sempre di tipo `password` e non è configurabile tramite context.

--- a/docs/it/components/LogoLoader.md
+++ b/docs/it/components/LogoLoader.md
@@ -1,0 +1,69 @@
+# LogoLoader
+
+> [English](../../../docs/components/LogoLoader.md) | [Versión española](../../../docs/es/components/LogoLoader.md)
+
+## Panoramica
+
+`LogoLoader` renderizza un anello SVG circolare rotante attorno a un'immagine logo. Viene usato internamente da `Loader`, ma può essere usato in modo standalone ogni volta che serve un'animazione logo-con-anello. L'anello ruota con una rotazione lenta di 2.2 secondi definita in `src/css/loader.css`.
+
+## Import
+
+```js
+import { LogoLoader } from 'thecore-auth';
+```
+
+## Props
+
+| Nome | Tipo | Default | Obbligatorio | Descrizione |
+|---|---|---|---|---|
+| `sizeContainer` | `string` | `'h-60 w-60'` | No | Classi Tailwind di dimensione per il container esterno |
+| `Logo` | `ComponentType` | `undefined` | No | Componente React (tipicamente un SVG) renderizzato come logo centrale. Deve accettare una prop `className` |
+| `spinnerColor` | `string` | `'#60A5FA'` | No | Valore CSS del colore per il tratto dell'anello SVG |
+
+## Variabili CSS
+
+`LogoLoader` non usa proprietà CSS custom. L'animazione di rotazione è definita in `src/css/loader.css`:
+
+| Classe | Animazione |
+|---|---|
+| `animate-spin-slow` | Rotazione 360°, 2.2 s, lineare, infinita |
+
+## Utilizzo
+
+```jsx
+import { LogoLoader } from 'thecore-auth';
+import MyLogo from './assets/MyLogo.svg?react';
+
+// Utilizzo standalone con dimensione e colore custom
+function SplashScreen() {
+  return (
+    <div className="flex items-center justify-center h-screen bg-indigo-50">
+      <LogoLoader
+        Logo={MyLogo}
+        sizeContainer="h-[200px] w-[200px]"
+        spinnerColor="#6366f1"
+      />
+    </div>
+  );
+}
+```
+
+### Dimensione predefinita con logo
+
+```jsx
+<LogoLoader Logo={MyLogo} />
+```
+
+### Senza logo (solo anello)
+
+```jsx
+// La prop Logo è opzionale — renderizza solo l'anello rotante
+<LogoLoader sizeContainer="h-20 w-20" spinnerColor="#f43f5e" />
+```
+
+## Note
+
+- L'anello SVG usa `strokeDasharray="280"` e `strokeDashoffset="210"` per renderizzare un arco anziché un cerchio completo.
+- Il componente `Logo` viene renderizzato all'interno di un `<figure>` con `rounded-full overflow-hidden`, quindi i logo rettangolari verranno ritagliati a cerchio.
+- Importa `loader.css` (o assicurati che l'app host importi il bundle CSS di `thecore-auth`) affinché la classe `animate-spin-slow` abbia effetto.
+- Quando usato all'interno di `Loader`, `sizeContainer` è controllato dalla prop `containerSize` di `Loader`.


### PR DESCRIPTION
## Summary
- 6 UI component reference files in EN + IT + ES (18 files total)
- Covers: LoginForm, Loading, LoadingComponent, Alert, Loader, LogoLoader
- Schema: Overview · Import · Props · CSS Variables · Usage · Notes

Closes #12