### PR TITLE
docs(components): add Modal internal components reference docs

### DIFF
--- a/docs/components/Modal.md
+++ b/docs/components/Modal.md
@@ -1,0 +1,60 @@
+# Modal
+
+> [Versione italiana](../../docs/it/components/Modal.md) | [Versión española](../../docs/es/components/Modal.md)
+
+> ⚙️ **Internal component** — not directly importable. Used inside `DefaultLayout`.
+> Interact with the modal system via [`useModal`](../contexts/ModalProvider.md).
+
+## Overview
+
+`Modal` is the root modal component. It renders a portal into `document.body`, manages open/close animation, traps keyboard focus, and closes on `Escape` or backdrop click. It composes `ModalHeader`, `ModalMain`, and `ModalFooter` — each of which can be replaced by a custom slot via `headerContent` / `footerContent`.
+
+Three behavioral modes are available via the `type` prop:
+- `submit` — renders a form-linked save/reset/cancel footer; the `formId` prop connects the submit button to a `<form>`.
+- `delete` — compact width, no main area, header shows an item-name confirmation question, footer has a destructive confirm button.
+- `custom` — footer confirm button calls `onConfirm` directly without submitting a form.
+
+## Props
+
+| Name | Type | Default | Required | Description |
+|---|---|---|---|---|
+| `isOpen` | `boolean` | — | ✅ | Controls modal visibility and entrance animation |
+| `onClose` | `function` | — | ✅ | Called when the modal should close (backdrop click, ESC, close button) |
+| `onCancel` | `function` | `undefined` | — | If provided, replaces `onClose` for ESC, backdrop click, and header/cancel-button actions |
+| `title` | `string` | `undefined` | — | Title rendered in `ModalHeader` (unused when `type === 'delete'` and `item.name` is set) |
+| `formId` | `string` | `undefined` | — | HTML form `id` linked to the submit/reset buttons in `ModalFooter` |
+| `children` | `ReactNode` | `undefined` | — | Content rendered inside `ModalMain` |
+| `item` | `object` | `undefined` | — | Item being acted on; `item.name` appears in the delete confirmation header |
+| `onConfirm` | `function` | `undefined` | — | Called on confirm action for `delete` and `custom` types |
+| `type` | `string` | `'submit'` | — | Modal behavior mode: `'submit'` \| `'delete'` \| `'custom'` |
+| `style` | `object` | `{}` | — | Style overrides object — see the Style object keys table below |
+| `headerContent` | `ReactNode` | `undefined` | — | Replaces `ModalHeader` entirely when provided |
+| `footerContent` | `ReactNode` | `undefined` | — | Replaces `ModalFooter` entirely when provided |
+
+### `style` object keys
+
+| Key | Type | Default | Description |
+|---|---|---|---|
+| `style.width` | `string` | `'max-w-md w-auto'` (delete) / `'w-full max-w-4xl'` | Tailwind width classes for the modal container |
+| `style.bgModal` | `string` | `'bg-white'` | Background color class for the modal panel |
+| `style.bgOverlay` | `string` | `'bg-black/50'` | Background color class for the backdrop overlay |
+| `style.zIndex` | `string` | `'z-50'` | z-index class for the overlay |
+| `style.overlayStyle` | `string` | `undefined` | Full class string override for the outer overlay `<div>` (replaces all defaults) |
+| `style.modalStyle` | `string` | `undefined` | Full class string override for the inner modal panel (replaces all defaults) |
+| `style.overrideStyle` | `string` | `undefined` | Passed to `ModalMain`; replaces the default `<main>` class string |
+| `style.resetButton` | `boolean` | `true` | Whether the reset button is shown in `ModalFooter` (ignored for `delete` type) |
+| `style.confirmButtonText` | `string` | `'Salva'` / `'Elimina'` | Text for the confirm button |
+| `style.cancelButtonText` | `string` | `'Annulla'` | Text for the cancel button |
+| `style.bgSaveButton` | `string` | indigo Tailwind classes | Classes for the save button (submit/custom types) |
+| `style.bgDeleteButton` | `string` | rose Tailwind classes | Classes for the delete confirm button |
+| `style.bgResetButton` | `string` | rose Tailwind classes | Classes for the reset button |
+| `style.bgCancelButton` | `string` | gray Tailwind classes | Classes for the cancel button |
+| `style.customButtonStyle` | `string` | `null` | Full class override for the confirm button when `type === 'custom'` |
+
+## Notes
+
+- `Modal` uses `ReactDOM.createPortal` to render into `document.body`, so it is unaffected by ancestor `overflow` or `z-index` stacking contexts.
+- On open, focus moves to the modal panel and is restored to the previously focused element on close.
+- If both `onCancel` and `onClose` are provided, `onCancel` is called first for ESC and backdrop/header-button actions; `onClose` is still used internally after delete confirmation.
+- `headerContent` and `footerContent` are escape hatches — prefer `style` overrides for visual customization.
+- The full `useModal` API (openModal, closeModal, style reference) is documented in [`docs/modal.md`](../modal.md).

--- a/docs/components/ModalFooter.md
+++ b/docs/components/ModalFooter.md
@@ -1,0 +1,48 @@
+# ModalFooter
+
+> [Versione italiana](../../docs/it/components/ModalFooter.md) | [Versión española](../../docs/es/components/ModalFooter.md)
+
+> ⚙️ **Internal component** — not directly importable. Used inside `DefaultLayout`.
+> Interact with the modal system via [`useModal`](../contexts/ModalProvider.md).
+
+## Overview
+
+`ModalFooter` renders the action buttons at the bottom of the modal. Button layout and behavior depend on `type`:
+
+- `submit` — cancel + reset + submit (linked to `formId`)
+- `delete` — cancel + destructive confirm (calls `onConfirm`, then `onClose`)
+- `custom` — cancel + confirm (calls `onConfirm` only, does not close automatically)
+
+`Modal` renders `ModalFooter` by default; pass `footerContent` to `Modal` to replace it entirely.
+
+## Props
+
+| Name | Type | Default | Required | Description |
+|---|---|---|---|---|
+| `onClose` | `function` | — | ✅ | Called when cancel is clicked; also called after `onConfirm` for `delete` type |
+| `onCancel` | `function` | `undefined` | — | If provided, takes precedence over `onClose` for the cancel button |
+| `onConfirm` | `function` | `undefined` | — | Called on confirm for `delete` and `custom` types |
+| `type` | `string` | — | ✅ | Modal type: `'submit'` \| `'delete'` \| `'custom'` |
+| `formId` | `string` | `undefined` | — | HTML form `id` linked to the submit/reset buttons (used in `submit` mode) |
+| `style` | `object` | `{}` | — | Style overrides — see the style keys table below |
+
+### `style` object keys
+
+| Key | Type | Default | Description |
+|---|---|---|---|
+| `style.resetButton` | `boolean` | `true` | Whether to show the reset button (always hidden for `delete` type) |
+| `style.confirmButtonText` | `string` | `'Salva'` / `'Elimina'` | Text for the confirm button; default depends on `type` |
+| `style.cancelButtonText` | `string` | `'Annulla'` | Text for the cancel button |
+| `style.bgSaveButton` | `string` | indigo Tailwind classes | Classes for the save button (`submit` / `custom` types) |
+| `style.bgDeleteButton` | `string` | rose Tailwind classes | Classes for the delete confirm button |
+| `style.bgResetButton` | `string` | rose Tailwind classes | Classes for the reset button |
+| `style.bgCancelButton` | `string` | gray Tailwind classes | Classes for the cancel button |
+| `style.customButtonStyle` | `string` | `null` | Full class override for the confirm button when `type === 'custom'` |
+
+## Notes
+
+- For `delete` type: clicking confirm calls `onConfirm?.()` then `onClose?.()` — the modal closes after the action.
+- For `custom` type: clicking confirm calls `onConfirm?.()` only — the caller is responsible for closing the modal.
+- For `submit` type: the confirm button has `type="submit"` and `form={formId}`; the reset button has `type="reset"` and `form={formId}`.
+- The reset button is suppressed when `type === 'delete'`, regardless of `style.resetButton`.
+- The full `useModal` API is documented in [`docs/modal.md`](../modal.md).

--- a/docs/components/ModalHeader.md
+++ b/docs/components/ModalHeader.md
@@ -1,0 +1,32 @@
+# ModalHeader
+
+> [Versione italiana](../../docs/it/components/ModalHeader.md) | [Versión española](../../docs/es/components/ModalHeader.md)
+
+> ⚙️ **Internal component** — not directly importable. Used inside `DefaultLayout`.
+> Interact with the modal system via [`useModal`](../contexts/ModalProvider.md).
+
+## Overview
+
+`ModalHeader` renders the top section of the modal: a title on the left and an `×` close button on the right. Title content adapts to the modal type:
+
+- `type === 'delete'` and `name` is set → shows "Sei sicuro di volere eliminare: **{name}**?"
+- otherwise → shows `title` if provided, falling back to `'Conferma operazione'`
+
+`Modal` renders `ModalHeader` by default; pass `headerContent` to `Modal` to replace it entirely.
+
+## Props
+
+| Name | Type | Default | Required | Description |
+|---|---|---|---|---|
+| `onClose` | `function` | — | ✅ | Called when the `×` button is clicked (unless `onCancel` is provided) |
+| `onCancel` | `function` | `undefined` | — | If provided, takes precedence over `onClose` for the `×` button click |
+| `type` | `string` | — | ✅ | Modal type: `'submit'` \| `'delete'` \| `'custom'`; controls title rendering logic |
+| `title` | `string` | `'Conferma operazione'` | — | Title text shown when `type !== 'delete'` or `name` is absent |
+| `name` | `string` | `undefined` | — | Item name used in the delete confirmation question |
+
+## Notes
+
+- The `×` button is always rendered regardless of `type`.
+- The close button has a scale/opacity hover animation and an `aria-label="Chiudi modale"` for accessibility.
+- To show a custom header, pass `headerContent` to `Modal` instead of overriding `ModalHeader` directly.
+- The full `useModal` API is documented in [`docs/modal.md`](../modal.md).

--- a/docs/components/ModalMain.md
+++ b/docs/components/ModalMain.md
@@ -1,0 +1,27 @@
+# ModalMain
+
+> [Versione italiana](../../docs/it/components/ModalMain.md) | [Versión española](../../docs/es/components/ModalMain.md)
+
+> ⚙️ **Internal component** — not directly importable. Used inside `DefaultLayout`.
+> Interact with the modal system via [`useModal`](../contexts/ModalProvider.md).
+
+## Overview
+
+`ModalMain` renders the scrollable content area of the modal. It wraps `children` in a `<main>` element with a fixed max-height and vertical scroll.
+
+When `type === 'delete'`, the entire `<main>` is suppressed — delete modals contain no body content, only the header confirmation question and the footer action buttons.
+
+## Props
+
+| Name | Type | Default | Required | Description |
+|---|---|---|---|---|
+| `type` | `string` | — | ✅ | Modal type: `'submit'` \| `'delete'` \| `'custom'`. When `'delete'`, nothing is rendered |
+| `children` | `ReactNode` | `undefined` | — | Content rendered inside the scrollable `<main>` area |
+| `item` | `object` | `undefined` | — | Item being acted on; when `type === 'delete'` and `item` is absent, an error message is shown instead of `children` |
+| `overrideStyle` | `string` | `undefined` | — | Replaces the default class string (`my-8 max-h-[600px] overflow-y-auto overflow-x-hidden`) when provided |
+
+## Notes
+
+- The default max-height is `600px`; use `overrideStyle` (via `style.overrideStyle` on `Modal`) to change it.
+- The internal error state (`type === 'delete'` with no `item`) is a defensive check that is never visible in normal use — `Modal` always supplies `item` for delete modals.
+- The full `useModal` API is documented in [`docs/modal.md`](../modal.md).

--- a/docs/es/components/Modal.md
+++ b/docs/es/components/Modal.md
@@ -1,0 +1,59 @@
+# Modal
+
+> [English](../../../docs/components/Modal.md) | [Versione italiana](../../../docs/it/components/Modal.md)
+
+> ⚙️ **Componente interno** — no importable directamente. Usado dentro de `DefaultLayout`. Interactúa con el sistema modal a través de [`useModal`](../../contexts/ModalProvider.md).
+
+## Descripción general
+
+`Modal` es el componente raíz del modal. Renderiza un portal en `document.body`, gestiona la animación de apertura/cierre, atrapa el foco del teclado y se cierra con `Escape` o al hacer clic en el fondo. Compone `ModalHeader`, `ModalMain` y `ModalFooter`, cada uno de los cuales puede sustituirse por un slot personalizado mediante `headerContent` / `footerContent`.
+
+Hay tres modos de comportamiento disponibles a través de la prop `type`:
+- `submit` — renderiza un pie de página con botones de guardar/resetear/cancelar enlazados a un formulario; la prop `formId` conecta el botón de envío con un `<form>`.
+- `delete` — ancho compacto, sin área principal, el encabezado muestra una pregunta de confirmación con el nombre del elemento, el pie de página tiene un botón de confirmación destructivo.
+- `custom` — el botón de confirmación del pie de página llama a `onConfirm` directamente sin enviar ningún formulario.
+
+## Props
+
+| Nombre | Tipo | Por defecto | Requerido | Descripción |
+|---|---|---|---|---|
+| `isOpen` | `boolean` | — | ✅ | Controla la visibilidad del modal y la animación de entrada |
+| `onClose` | `function` | — | ✅ | Se invoca cuando el modal debe cerrarse (clic en el fondo, ESC, botón de cierre) |
+| `onCancel` | `function` | `undefined` | — | Si se proporciona, reemplaza a `onClose` para ESC, clic en el fondo y acciones del encabezado/botón de cancelar |
+| `title` | `string` | `undefined` | — | Título renderizado en `ModalHeader` (no se usa cuando `type === 'delete'` e `item.name` está definido) |
+| `formId` | `string` | `undefined` | — | `id` del formulario HTML enlazado a los botones de envío/reseteo en `ModalFooter` |
+| `children` | `ReactNode` | `undefined` | — | Contenido renderizado dentro de `ModalMain` |
+| `item` | `object` | `undefined` | — | Elemento sobre el que se actúa; `item.name` aparece en el encabezado de confirmación de eliminación |
+| `onConfirm` | `function` | `undefined` | — | Se invoca en la acción de confirmar para los tipos `delete` y `custom` |
+| `type` | `string` | `'submit'` | — | Modo de comportamiento del modal: `'submit'` \| `'delete'` \| `'custom'` |
+| `style` | `object` | `{}` | — | Objeto de sobreescritura de estilos — ver la tabla de claves del objeto `style` más abajo |
+| `headerContent` | `ReactNode` | `undefined` | — | Reemplaza completamente `ModalHeader` cuando se proporciona |
+| `footerContent` | `ReactNode` | `undefined` | — | Reemplaza completamente `ModalFooter` cuando se proporciona |
+
+### Claves del objeto `style`
+
+| Clave | Tipo | Por defecto | Descripción |
+|---|---|---|---|
+| `style.width` | `string` | `'max-w-md w-auto'` (delete) / `'w-full max-w-4xl'` | Clases Tailwind de ancho para el contenedor del modal |
+| `style.bgModal` | `string` | `'bg-white'` | Clase de color de fondo para el panel del modal |
+| `style.bgOverlay` | `string` | `'bg-black/50'` | Clase de color de fondo para el fondo semitransparente |
+| `style.zIndex` | `string` | `'z-50'` | Clase de z-index para el overlay |
+| `style.overlayStyle` | `string` | `undefined` | Cadena de clases completa para el `<div>` externo del overlay (reemplaza todos los valores por defecto) |
+| `style.modalStyle` | `string` | `undefined` | Cadena de clases completa para el panel interno del modal (reemplaza todos los valores por defecto) |
+| `style.overrideStyle` | `string` | `undefined` | Se pasa a `ModalMain`; reemplaza la cadena de clases del `<main>` por defecto |
+| `style.resetButton` | `boolean` | `true` | Si el botón de reseteo se muestra en `ModalFooter` (ignorado para el tipo `delete`) |
+| `style.confirmButtonText` | `string` | `'Salva'` / `'Elimina'` | Texto del botón de confirmación |
+| `style.cancelButtonText` | `string` | `'Annulla'` | Texto del botón de cancelar |
+| `style.bgSaveButton` | `string` | clases Tailwind índigo | Clases para el botón de guardar (tipos `submit`/`custom`) |
+| `style.bgDeleteButton` | `string` | clases Tailwind rosa | Clases para el botón de confirmación de eliminación |
+| `style.bgResetButton` | `string` | clases Tailwind rosa | Clases para el botón de reseteo |
+| `style.bgCancelButton` | `string` | clases Tailwind gris | Clases para el botón de cancelar |
+| `style.customButtonStyle` | `string` | `null` | Sobreescritura completa de clases para el botón de confirmación cuando `type === 'custom'` |
+
+## Notas
+
+- `Modal` utiliza `ReactDOM.createPortal` para renderizar en `document.body`, por lo que no se ve afectado por el contexto de apilamiento `overflow` o `z-index` de los elementos ancestros.
+- Al abrirse, el foco se mueve al panel del modal y se restaura al elemento previamente enfocado al cerrarse.
+- Si se proporcionan tanto `onCancel` como `onClose`, `onCancel` se invoca primero para ESC y las acciones del fondo/botón del encabezado; `onClose` sigue utilizándose internamente tras la confirmación de eliminación.
+- `headerContent` y `footerContent` son vías de escape — se recomienda usar sobreescrituras de `style` para la personalización visual.
+- La API completa de `useModal` (openModal, closeModal, referencia de style) está documentada en [`docs/modal.md`](../modal.md).

--- a/docs/es/components/ModalFooter.md
+++ b/docs/es/components/ModalFooter.md
@@ -1,0 +1,47 @@
+# ModalFooter
+
+> [English](../../../docs/components/ModalFooter.md) | [Versione italiana](../../../docs/it/components/ModalFooter.md)
+
+> ⚙️ **Componente interno** — no importable directamente. Usado dentro de `DefaultLayout`. Interactúa con el sistema modal a través de [`useModal`](../../contexts/ModalProvider.md).
+
+## Descripción general
+
+`ModalFooter` renderiza los botones de acción en la parte inferior del modal. La disposición y el comportamiento de los botones dependen del `type`:
+
+- `submit` — cancelar + resetear + enviar (enlazado a `formId`)
+- `delete` — cancelar + confirmar destructivo (llama a `onConfirm`, luego a `onClose`)
+- `custom` — cancelar + confirmar (llama solo a `onConfirm`, no cierra automáticamente)
+
+`Modal` renderiza `ModalFooter` por defecto; se puede pasar `footerContent` a `Modal` para reemplazarlo completamente.
+
+## Props
+
+| Nombre | Tipo | Por defecto | Requerido | Descripción |
+|---|---|---|---|---|
+| `onClose` | `function` | — | ✅ | Se invoca cuando se hace clic en cancelar; también se invoca después de `onConfirm` para el tipo `delete` |
+| `onCancel` | `function` | `undefined` | — | Si se proporciona, tiene precedencia sobre `onClose` para el botón de cancelar |
+| `onConfirm` | `function` | `undefined` | — | Se invoca en la confirmación para los tipos `delete` y `custom` |
+| `type` | `string` | — | ✅ | Tipo del modal: `'submit'` \| `'delete'` \| `'custom'` |
+| `formId` | `string` | `undefined` | — | `id` del formulario HTML enlazado a los botones de envío/reseteo (usado en el modo `submit`) |
+| `style` | `object` | `{}` | — | Sobreescrituras de estilo — ver la tabla de claves de style más abajo |
+
+### Claves del objeto `style`
+
+| Clave | Tipo | Por defecto | Descripción |
+|---|---|---|---|
+| `style.resetButton` | `boolean` | `true` | Si mostrar el botón de reseteo (siempre oculto para el tipo `delete`) |
+| `style.confirmButtonText` | `string` | `'Salva'` / `'Elimina'` | Texto del botón de confirmación; el valor por defecto depende del `type` |
+| `style.cancelButtonText` | `string` | `'Annulla'` | Texto del botón de cancelar |
+| `style.bgSaveButton` | `string` | clases Tailwind índigo | Clases para el botón de guardar (tipos `submit` / `custom`) |
+| `style.bgDeleteButton` | `string` | clases Tailwind rosa | Clases para el botón de confirmación de eliminación |
+| `style.bgResetButton` | `string` | clases Tailwind rosa | Clases para el botón de reseteo |
+| `style.bgCancelButton` | `string` | clases Tailwind gris | Clases para el botón de cancelar |
+| `style.customButtonStyle` | `string` | `null` | Sobreescritura completa de clases para el botón de confirmación cuando `type === 'custom'` |
+
+## Notas
+
+- Para el tipo `delete`: al hacer clic en confirmar se llama a `onConfirm?.()` y luego a `onClose?.()` — el modal se cierra tras la acción.
+- Para el tipo `custom`: al hacer clic en confirmar se llama solo a `onConfirm?.()` — el llamador es responsable de cerrar el modal.
+- Para el tipo `submit`: el botón de confirmación tiene `type="submit"` y `form={formId}`; el botón de reseteo tiene `type="reset"` y `form={formId}`.
+- El botón de reseteo se suprime cuando `type === 'delete'`, independientemente del valor de `style.resetButton`.
+- La API completa de `useModal` está documentada en [`docs/modal.md`](../modal.md).

--- a/docs/es/components/ModalHeader.md
+++ b/docs/es/components/ModalHeader.md
@@ -1,0 +1,31 @@
+# ModalHeader
+
+> [English](../../../docs/components/ModalHeader.md) | [Versione italiana](../../../docs/it/components/ModalHeader.md)
+
+> ⚙️ **Componente interno** — no importable directamente. Usado dentro de `DefaultLayout`. Interactúa con el sistema modal a través de [`useModal`](../../contexts/ModalProvider.md).
+
+## Descripción general
+
+`ModalHeader` renderiza la sección superior del modal: un título a la izquierda y un botón de cierre `×` a la derecha. El contenido del título se adapta al tipo de modal:
+
+- `type === 'delete'` y `name` está definido → muestra "Sei sicuro di volere eliminare: **{name}**?"
+- en caso contrario → muestra `title` si se ha proporcionado, con `'Conferma operazione'` como valor de reserva
+
+`Modal` renderiza `ModalHeader` por defecto; se puede pasar `headerContent` a `Modal` para reemplazarlo completamente.
+
+## Props
+
+| Nombre | Tipo | Por defecto | Requerido | Descripción |
+|---|---|---|---|---|
+| `onClose` | `function` | — | ✅ | Se invoca cuando se hace clic en el botón `×` (a menos que se haya proporcionado `onCancel`) |
+| `onCancel` | `function` | `undefined` | — | Si se proporciona, tiene precedencia sobre `onClose` para el clic en el botón `×` |
+| `type` | `string` | — | ✅ | Tipo del modal: `'submit'` \| `'delete'` \| `'custom'`; controla la lógica de renderizado del título |
+| `title` | `string` | `'Conferma operazione'` | — | Texto del título mostrado cuando `type !== 'delete'` o `name` está ausente |
+| `name` | `string` | `undefined` | — | Nombre del elemento usado en la pregunta de confirmación de eliminación |
+
+## Notas
+
+- El botón `×` siempre se renderiza independientemente del `type`.
+- El botón de cierre tiene una animación de escala/opacidad al pasar el cursor y un `aria-label="Chiudi modale"` para la accesibilidad.
+- Para mostrar un encabezado personalizado, se debe pasar `headerContent` a `Modal` en lugar de sobreescribir `ModalHeader` directamente.
+- La API completa de `useModal` está documentada en [`docs/modal.md`](../modal.md).

--- a/docs/es/components/ModalMain.md
+++ b/docs/es/components/ModalMain.md
@@ -1,0 +1,26 @@
+# ModalMain
+
+> [English](../../../docs/components/ModalMain.md) | [Versione italiana](../../../docs/it/components/ModalMain.md)
+
+> ⚙️ **Componente interno** — no importable directamente. Usado dentro de `DefaultLayout`. Interactúa con el sistema modal a través de [`useModal`](../../contexts/ModalProvider.md).
+
+## Descripción general
+
+`ModalMain` renderiza el área de contenido desplazable del modal. Envuelve `children` en un elemento `<main>` con altura máxima fija y scroll vertical.
+
+Cuando `type === 'delete'`, el `<main>` completo se suprime — los modales de eliminación no contienen cuerpo, solo la pregunta de confirmación del encabezado y los botones de acción del pie de página.
+
+## Props
+
+| Nombre | Tipo | Por defecto | Requerido | Descripción |
+|---|---|---|---|---|
+| `type` | `string` | — | ✅ | Tipo del modal: `'submit'` \| `'delete'` \| `'custom'`. Cuando es `'delete'`, no se renderiza nada |
+| `children` | `ReactNode` | `undefined` | — | Contenido renderizado dentro del área `<main>` desplazable |
+| `item` | `object` | `undefined` | — | Elemento sobre el que se actúa; cuando `type === 'delete'` e `item` está ausente, se muestra un mensaje de error en lugar de `children` |
+| `overrideStyle` | `string` | `undefined` | — | Reemplaza la cadena de clases por defecto (`my-8 max-h-[600px] overflow-y-auto overflow-x-hidden`) cuando se proporciona |
+
+## Notas
+
+- La altura máxima por defecto es `600px`; se puede cambiar con `overrideStyle` (mediante `style.overrideStyle` en `Modal`).
+- El estado de error interno (`type === 'delete'` sin `item`) es una comprobación defensiva que no es visible en el uso normal — `Modal` siempre proporciona `item` para los modales de eliminación.
+- La API completa de `useModal` está documentada en [`docs/modal.md`](../modal.md).

--- a/docs/it/components/Modal.md
+++ b/docs/it/components/Modal.md
@@ -1,0 +1,59 @@
+# Modal
+
+> [English](../../../docs/components/Modal.md) | [Versión española](../../../docs/es/components/Modal.md)
+
+> ⚙️ **Componente interno** — non importabile direttamente. Utilizzato all'interno di `DefaultLayout`. Interagisci con il sistema modale tramite [`useModal`](../../contexts/ModalProvider.md).
+
+## Panoramica
+
+`Modal` è il componente radice del modale. Esegue il rendering tramite un portale in `document.body`, gestisce l'animazione di apertura/chiusura, intrappola il focus della tastiera e si chiude alla pressione di `Escape` o al click sul backdrop. Compone `ModalHeader`, `ModalMain` e `ModalFooter` — ognuno dei quali può essere sostituito da uno slot personalizzato tramite `headerContent` / `footerContent`.
+
+Tramite la prop `type` sono disponibili tre modalità comportamentali:
+- `submit` — renderizza un footer con pulsanti salva/reset/annulla collegati a un form; la prop `formId` collega il pulsante di submit a un `<form>`.
+- `delete` — larghezza ridotta, nessuna area principale, l'header mostra una domanda di conferma con il nome dell'elemento, il footer contiene un pulsante di conferma distruttivo.
+- `custom` — il pulsante di conferma nel footer chiama `onConfirm` direttamente senza inviare un form.
+
+## Props
+
+| Nome | Tipo | Default | Richiesto | Descrizione |
+|---|---|---|---|---|
+| `isOpen` | `boolean` | — | ✅ | Controlla la visibilità del modale e l'animazione di ingresso |
+| `onClose` | `function` | — | ✅ | Chiamata quando il modale deve chiudersi (click sul backdrop, ESC, pulsante chiudi) |
+| `onCancel` | `function` | `undefined` | — | Se fornita, sostituisce `onClose` per le azioni ESC, click sul backdrop e pulsante di chiusura/annullamento |
+| `title` | `string` | `undefined` | — | Titolo renderizzato in `ModalHeader` (non utilizzato quando `type === 'delete'` e `item.name` è impostato) |
+| `formId` | `string` | `undefined` | — | `id` HTML del form collegato ai pulsanti submit/reset in `ModalFooter` |
+| `children` | `ReactNode` | `undefined` | — | Contenuto renderizzato all'interno di `ModalMain` |
+| `item` | `object` | `undefined` | — | Elemento su cui si agisce; `item.name` appare nell'header di conferma eliminazione |
+| `onConfirm` | `function` | `undefined` | — | Chiamata all'azione di conferma per i tipi `delete` e `custom` |
+| `type` | `string` | `'submit'` | — | Modalità comportamentale del modale: `'submit'` \| `'delete'` \| `'custom'` |
+| `style` | `object` | `{}` | — | Oggetto di sovrascrittura degli stili — vedi la tabella delle chiavi dell'oggetto `style` qui sotto |
+| `headerContent` | `ReactNode` | `undefined` | — | Sostituisce completamente `ModalHeader` quando fornito |
+| `footerContent` | `ReactNode` | `undefined` | — | Sostituisce completamente `ModalFooter` quando fornito |
+
+### Chiavi dell'oggetto `style`
+
+| Chiave | Tipo | Default | Descrizione |
+|---|---|---|---|
+| `style.width` | `string` | `'max-w-md w-auto'` (delete) / `'w-full max-w-4xl'` | Classi Tailwind per la larghezza del contenitore del modale |
+| `style.bgModal` | `string` | `'bg-white'` | Classe per il colore di sfondo del pannello modale |
+| `style.bgOverlay` | `string` | `'bg-black/50'` | Classe per il colore di sfondo del backdrop |
+| `style.zIndex` | `string` | `'z-50'` | Classe z-index per l'overlay |
+| `style.overlayStyle` | `string` | `undefined` | Stringa di classi completa per il `<div>` overlay esterno (sostituisce tutti i default) |
+| `style.modalStyle` | `string` | `undefined` | Stringa di classi completa per il pannello modale interno (sostituisce tutti i default) |
+| `style.overrideStyle` | `string` | `undefined` | Passato a `ModalMain`; sostituisce la stringa di classi predefinita del `<main>` |
+| `style.resetButton` | `boolean` | `true` | Se mostrare il pulsante reset in `ModalFooter` (ignorato per il tipo `delete`) |
+| `style.confirmButtonText` | `string` | `'Salva'` / `'Elimina'` | Testo del pulsante di conferma |
+| `style.cancelButtonText` | `string` | `'Annulla'` | Testo del pulsante di annullamento |
+| `style.bgSaveButton` | `string` | classi Tailwind indigo | Classi per il pulsante salva (tipi `submit`/`custom`) |
+| `style.bgDeleteButton` | `string` | classi Tailwind rose | Classi per il pulsante di conferma eliminazione |
+| `style.bgResetButton` | `string` | classi Tailwind rose | Classi per il pulsante reset |
+| `style.bgCancelButton` | `string` | classi Tailwind gray | Classi per il pulsante di annullamento |
+| `style.customButtonStyle` | `string` | `null` | Sovrascrittura completa delle classi del pulsante di conferma quando `type === 'custom'` |
+
+## Note
+
+- `Modal` usa `ReactDOM.createPortal` per renderizzare in `document.body`, quindi non è influenzato dai contesti di impilamento `overflow` o `z-index` degli elementi antenato.
+- All'apertura, il focus si sposta sul pannello modale e viene ripristinato sull'elemento precedentemente focalizzato alla chiusura.
+- Se sono forniti sia `onCancel` che `onClose`, `onCancel` viene chiamato prima per ESC e le azioni sul backdrop/pulsante header; `onClose` viene comunque utilizzato internamente dopo la conferma di eliminazione.
+- `headerContent` e `footerContent` sono vie di fuga — preferire le sovrascritture tramite `style` per la personalizzazione visiva.
+- L'API completa di `useModal` (openModal, closeModal, riferimento agli stili) è documentata in [`docs/modal.md`](../modal.md).

--- a/docs/it/components/ModalFooter.md
+++ b/docs/it/components/ModalFooter.md
@@ -1,0 +1,47 @@
+# ModalFooter
+
+> [English](../../../docs/components/ModalFooter.md) | [Versión española](../../../docs/es/components/ModalFooter.md)
+
+> ⚙️ **Componente interno** — non importabile direttamente. Utilizzato all'interno di `DefaultLayout`. Interagisci con il sistema modale tramite [`useModal`](../../contexts/ModalProvider.md).
+
+## Panoramica
+
+`ModalFooter` renderizza i pulsanti di azione nella parte inferiore del modale. Il layout e il comportamento dei pulsanti dipendono dal `type`:
+
+- `submit` — annulla + reset + submit (collegato a `formId`)
+- `delete` — annulla + conferma distruttiva (chiama `onConfirm`, poi `onClose`)
+- `custom` — annulla + conferma (chiama solo `onConfirm`, non si chiude automaticamente)
+
+`Modal` renderizza `ModalFooter` di default; passa `footerContent` a `Modal` per sostituirlo interamente.
+
+## Props
+
+| Nome | Tipo | Default | Richiesto | Descrizione |
+|---|---|---|---|---|
+| `onClose` | `function` | — | ✅ | Chiamata quando si clicca annulla; chiamata anche dopo `onConfirm` per il tipo `delete` |
+| `onCancel` | `function` | `undefined` | — | Se fornita, ha la precedenza su `onClose` per il pulsante di annullamento |
+| `onConfirm` | `function` | `undefined` | — | Chiamata alla conferma per i tipi `delete` e `custom` |
+| `type` | `string` | — | ✅ | Tipo di modale: `'submit'` \| `'delete'` \| `'custom'` |
+| `formId` | `string` | `undefined` | — | `id` HTML del form collegato ai pulsanti submit/reset (utilizzato nella modalità `submit`) |
+| `style` | `object` | `{}` | — | Sovrascritture degli stili — vedi la tabella delle chiavi qui sotto |
+
+### Chiavi dell'oggetto `style`
+
+| Chiave | Tipo | Default | Descrizione |
+|---|---|---|---|
+| `style.resetButton` | `boolean` | `true` | Se mostrare il pulsante reset (sempre nascosto per il tipo `delete`) |
+| `style.confirmButtonText` | `string` | `'Salva'` / `'Elimina'` | Testo del pulsante di conferma; il default dipende dal `type` |
+| `style.cancelButtonText` | `string` | `'Annulla'` | Testo del pulsante di annullamento |
+| `style.bgSaveButton` | `string` | classi Tailwind indigo | Classi per il pulsante salva (tipi `submit` / `custom`) |
+| `style.bgDeleteButton` | `string` | classi Tailwind rose | Classi per il pulsante di conferma eliminazione |
+| `style.bgResetButton` | `string` | classi Tailwind rose | Classi per il pulsante reset |
+| `style.bgCancelButton` | `string` | classi Tailwind gray | Classi per il pulsante di annullamento |
+| `style.customButtonStyle` | `string` | `null` | Sovrascrittura completa delle classi del pulsante di conferma quando `type === 'custom'` |
+
+## Note
+
+- Per il tipo `delete`: il click su conferma chiama `onConfirm?.()` poi `onClose?.()` — il modale si chiude dopo l'azione.
+- Per il tipo `custom`: il click su conferma chiama solo `onConfirm?.()` — è responsabilità del chiamante chiudere il modale.
+- Per il tipo `submit`: il pulsante di conferma ha `type="submit"` e `form={formId}`; il pulsante reset ha `type="reset"` e `form={formId}`.
+- Il pulsante reset viene soppresso quando `type === 'delete'`, indipendentemente da `style.resetButton`.
+- L'API completa di `useModal` è documentata in [`docs/modal.md`](../modal.md).

--- a/docs/it/components/ModalHeader.md
+++ b/docs/it/components/ModalHeader.md
@@ -1,0 +1,31 @@
+# ModalHeader
+
+> [English](../../../docs/components/ModalHeader.md) | [Versión española](../../../docs/es/components/ModalHeader.md)
+
+> ⚙️ **Componente interno** — non importabile direttamente. Utilizzato all'interno di `DefaultLayout`. Interagisci con il sistema modale tramite [`useModal`](../../contexts/ModalProvider.md).
+
+## Panoramica
+
+`ModalHeader` renderizza la sezione superiore del modale: un titolo a sinistra e un pulsante di chiusura `×` a destra. Il contenuto del titolo si adatta al tipo di modale:
+
+- `type === 'delete'` e `name` è impostato → mostra "Sei sicuro di volere eliminare: **{name}**?"
+- altrimenti → mostra `title` se fornito, con fallback a `'Conferma operazione'`
+
+`Modal` renderizza `ModalHeader` di default; passa `headerContent` a `Modal` per sostituirlo interamente.
+
+## Props
+
+| Nome | Tipo | Default | Richiesto | Descrizione |
+|---|---|---|---|---|
+| `onClose` | `function` | — | ✅ | Chiamata quando si clicca il pulsante `×` (a meno che non sia fornito `onCancel`) |
+| `onCancel` | `function` | `undefined` | — | Se fornita, ha la precedenza su `onClose` per il click del pulsante `×` |
+| `type` | `string` | — | ✅ | Tipo di modale: `'submit'` \| `'delete'` \| `'custom'`; controlla la logica di rendering del titolo |
+| `title` | `string` | `'Conferma operazione'` | — | Testo del titolo mostrato quando `type !== 'delete'` o `name` è assente |
+| `name` | `string` | `undefined` | — | Nome dell'elemento utilizzato nella domanda di conferma eliminazione |
+
+## Note
+
+- Il pulsante `×` viene sempre renderizzato indipendentemente dal `type`.
+- Il pulsante di chiusura ha un'animazione di scala/opacità al passaggio del cursore e un `aria-label="Chiudi modale"` per l'accessibilità.
+- Per mostrare un header personalizzato, passa `headerContent` a `Modal` invece di sovrascrivere `ModalHeader` direttamente.
+- L'API completa di `useModal` è documentata in [`docs/modal.md`](../modal.md).

--- a/docs/it/components/ModalMain.md
+++ b/docs/it/components/ModalMain.md
@@ -1,0 +1,26 @@
+# ModalMain
+
+> [English](../../../docs/components/ModalMain.md) | [Versión española](../../../docs/es/components/ModalMain.md)
+
+> ⚙️ **Componente interno** — non importabile direttamente. Utilizzato all'interno di `DefaultLayout`. Interagisci con il sistema modale tramite [`useModal`](../../contexts/ModalProvider.md).
+
+## Panoramica
+
+`ModalMain` renderizza l'area di contenuto scorrevole del modale. Avvolge `children` in un elemento `<main>` con altezza massima fissa e scroll verticale.
+
+Quando `type === 'delete'`, l'intero `<main>` viene soppresso — i modali di eliminazione non contengono contenuto nel corpo, solo la domanda di conferma nell'header e i pulsanti di azione nel footer.
+
+## Props
+
+| Nome | Tipo | Default | Richiesto | Descrizione |
+|---|---|---|---|---|
+| `type` | `string` | — | ✅ | Tipo di modale: `'submit'` \| `'delete'` \| `'custom'`. Quando è `'delete'`, non viene renderizzato nulla |
+| `children` | `ReactNode` | `undefined` | — | Contenuto renderizzato all'interno dell'area `<main>` scorrevole |
+| `item` | `object` | `undefined` | — | Elemento su cui si agisce; quando `type === 'delete'` e `item` è assente, viene mostrato un messaggio di errore al posto di `children` |
+| `overrideStyle` | `string` | `undefined` | — | Sostituisce la stringa di classi predefinita (`my-8 max-h-[600px] overflow-y-auto overflow-x-hidden`) quando fornita |
+
+## Note
+
+- L'altezza massima predefinita è `600px`; usa `overrideStyle` (tramite `style.overrideStyle` su `Modal`) per modificarla.
+- Lo stato di errore interno (`type === 'delete'` senza `item`) è un controllo difensivo che non è mai visibile in uso normale — `Modal` fornisce sempre `item` per i modali di eliminazione.
+- L'API completa di `useModal` è documentata in [`docs/modal.md`](../modal.md).


### PR DESCRIPTION
## Summary
- 4 Modal internal component reference files in EN + IT + ES (12 files total)
- Covers: Modal, ModalHeader, ModalMain, ModalFooter
- All marked as ⚙️ Internal — not directly importable
- Links back to existing docs/modal.md for the full useModal API

Closes #13