### PR TITLE
docs(components): add SPOT RFID components reference docs

### DIFF
--- a/docs/components/CardInputRange.md
+++ b/docs/components/CardInputRange.md
@@ -1,0 +1,74 @@
+# CardInputRange
+
+> [Versione italiana](../../docs/it/components/CardInputRange.md) | [Versión española](../../docs/es/components/CardInputRange.md)
+
+## Overview
+
+`CardInputRange` is a SPOT RFID card component for configuring RFID reader transmission power. It renders a styled range slider with a floating tooltip that tracks the current value, and a save button that commits the selected value.
+
+The card animates in from below based on the `show` prop. The tooltip position is calculated as a percentage of the range so it always aligns with the slider thumb.
+
+## Import
+
+```jsx
+import { CardInputRange } from 'thecore-auth';
+```
+
+## Props
+
+| Name | Type | Default | Required | Description |
+|---|---|---|---|---|
+| `minReadingPower` | `number` | — | ✅ | Minimum value of the power range slider |
+| `maxReadingPower` | `number` | — | ✅ | Maximum value of the power range slider |
+| `stepRangePower` | `number` | — | ✅ | Step increment of the slider |
+| `rangeValue` | `number` | — | ✅ | Current controlled value of the slider |
+| `setRangeValue` | `function` | — | ✅ | State setter called with the new numeric value when the slider changes |
+| `show` | `boolean` | — | ✅ | Controls the entrance animation — `true` makes the card visible, `false` hides it |
+| `handleClick` | `function` | — | ✅ | Callback invoked with the current `rangeValue` when the save button is clicked |
+
+## CSS Variables
+
+| Variable | Default | Description |
+|---|---|---|
+| `--color-primary-accent` | `#f56907` | Accent color used for the slider thumb and track fill |
+| `--color-save-button` | `#16A34A` | Background color of the save button |
+
+## Usage
+
+```jsx
+import { useState } from 'react';
+import { CardInputRange } from 'thecore-auth';
+
+function PowerConfig() {
+  const [power, setPower] = useState(20);
+  const [visible, setVisible] = useState(false);
+
+  const handleSave = (value) => {
+    console.log('Saving power level:', value);
+    // send to RFID reader API
+  };
+
+  return (
+    <div>
+      <button onClick={() => setVisible(true)}>Configure power</button>
+
+      <CardInputRange
+        minReadingPower={0}
+        maxReadingPower={30}
+        stepRangePower={1}
+        rangeValue={power}
+        setRangeValue={setPower}
+        show={visible}
+        handleClick={handleSave}
+      />
+    </div>
+  );
+}
+```
+
+## Notes
+
+- `setRangeValue` is called with a `Number` (via `Number(e.target.value)`) — the parent state must accept a number, not a string.
+- `handleClick` receives the current `rangeValue` as its first argument; it does not receive the native event.
+- The floating tooltip position can drift slightly at the extreme ends of the slider due to browser thumb width — this is a known cosmetic limitation of percentage-based tooltip positioning.
+- The slider uses the `accent-primary-accent` Tailwind class which maps to `--color-primary-accent`; overriding this variable changes the thumb and filled-track color.

--- a/docs/components/CardInputTag.md
+++ b/docs/components/CardInputTag.md
@@ -1,0 +1,80 @@
+# CardInputTag
+
+> [Versione italiana](../../docs/it/components/CardInputTag.md) | [Versión española](../../docs/es/components/CardInputTag.md)
+
+## Overview
+
+`CardInputTag` is a SPOT RFID card component that displays the TID and EPC values of a single RFID tag. It renders two read-only `InputGroup` fields and an optional write button. The card animates in from below using a CSS transition driven by the `showTag` prop.
+
+The write button is disabled automatically when both `valueTID` and `valueEPC` are empty, preventing writes before the reader has returned data.
+
+## Import
+
+```jsx
+import { CardInputTag } from 'thecore-auth';
+```
+
+## Props
+
+| Name | Type | Default | Required | Description |
+|---|---|---|---|---|
+| `title` | `string` | — | ✅ | Card heading text (e.g. `'TAG A'`, `'TAG B'`). Also used in placeholder text. The value `'TAG B'` applies an extra `delay-200` to the entrance animation. |
+| `showTag` | `boolean` | — | ✅ | Controls the entrance animation — `true` makes the card fully visible, `false` hides it with a downward offset. |
+| `value` | `object` | `undefined` | — | Object containing the tag data. Shape: `{ valueTID: string, valueEPC: string }`. |
+| `tag` | `string` | `undefined` | — | Suffix appended to the input `id` attributes (e.g. `'a'` → ids become `tid-a`, `epc-a`). Omit when rendering a single card. |
+| `showButton` | `boolean` | — | ✅ | When `true`, the write button is **hidden**. When `false`, the write button is visible. |
+| `handleClick` | `function` | `undefined` | — | Callback invoked when the write button is clicked. |
+
+## CSS Variables
+
+| Variable | Default | Description |
+|---|---|---|
+| `--color-write-button` | `#0284C7` | Background color of the write button |
+
+## Usage
+
+```jsx
+import { useState } from 'react';
+import { CardInputTag } from 'thecore-auth';
+
+function TagPanel() {
+  const [visible, setVisible] = useState(false);
+  const [tagData, setTagData] = useState({ valueTID: '', valueEPC: '' });
+
+  const handleWrite = () => {
+    console.log('Writing tag:', tagData);
+  };
+
+  return (
+    <div>
+      <button onClick={() => setVisible(true)}>Start reading</button>
+
+      <CardInputTag
+        title="TAG A"
+        showTag={visible}
+        value={tagData}
+        tag="a"
+        showButton={false}
+        handleClick={handleWrite}
+      />
+
+      {/* Second card with staggered animation delay */}
+      <CardInputTag
+        title="TAG B"
+        showTag={visible}
+        value={{ valueTID: 'E2003412AABBCCDD', valueEPC: '300833B2DDD9014000000000' }}
+        tag="b"
+        showButton={true}
+        handleClick={() => {}}
+      />
+    </div>
+  );
+}
+```
+
+## Notes
+
+- The write button is disabled (not hidden) when `value?.valueTID` and `value?.valueEPC` are both falsy. It becomes enabled as soon as either field is populated.
+- `showButton={true}` hides the button entirely (the prop name is inverted — it controls whether to hide, not show).
+- The `'TAG B'` title check is a hardcoded delay for staggered two-card layouts; for other title strings no delay is applied.
+- `tag` is used to make input `id` attributes unique when multiple cards appear on the same page. Omit it only when a single card is rendered.

--- a/docs/components/ConfigFileReader.md
+++ b/docs/components/ConfigFileReader.md
@@ -1,0 +1,56 @@
+# ConfigFileReader
+
+> [Versione italiana](../../docs/it/components/ConfigFileReader.md) | [Versión española](../../docs/es/components/ConfigFileReader.md)
+
+## Overview
+
+`ConfigFileReader` is a SPOT RFID component that presents a prompt and a button for selecting a `config.json` file. It is designed for environments where the native file-picker integration is provided externally (e.g. a WebView bridge or a custom file-system API) — the component itself only renders a button and delegates the actual file-open logic to `handleSelectFile`.
+
+The component supports an optional entrance animation controlled by the combination of `isConfigPage` and `show`.
+
+## Import
+
+```jsx
+import { ConfigFileReader } from 'thecore-auth';
+```
+
+## Props
+
+| Name | Type | Default | Required | Description |
+|---|---|---|---|---|
+| `handleSelectFile` | `function` | — | ✅ | Called when the "Seleziona file" button is clicked. Responsible for opening a file picker or triggering a native bridge. |
+| `show` | `boolean` | — | — | When `isConfigPage` is `true`, controls the entrance animation: `true` → visible, `false` → hidden with downward offset. |
+| `isConfigPage` | `boolean` | — | — | Enables the animated show/hide behavior driven by `show`. When `false`, the component is always fully visible without animation. |
+
+## CSS Variables
+
+This component does not use SPOT RFID-specific CSS variables. General layout variables from the host application apply.
+
+## Usage
+
+```jsx
+import { ConfigFileReader } from 'thecore-auth';
+
+function ConfigPage({ isReady }) {
+  const handleSelectFile = () => {
+    // Trigger a WebView bridge call or a custom native file dialog
+    window.NativeBridge?.openFilePicker('application/json');
+  };
+
+  return (
+    <div>
+      <ConfigFileReader
+        isConfigPage={true}
+        show={isReady}
+        handleSelectFile={handleSelectFile}
+      />
+    </div>
+  );
+}
+```
+
+## Notes
+
+- This component does **not** render a hidden `<input type="file">`. File selection is fully delegated to `handleSelectFile` — use [`ConfigFileReaderAllBrowser`](./ConfigFileReaderAllBrowser.md) for standard browser file-picker behavior.
+- The animation is only active when `isConfigPage={true}`. When `isConfigPage` is `false` or omitted, `show` has no effect.
+- The instruction text ("Seleziona il file **config.json**…") is fixed in Italian as a product requirement.

--- a/docs/components/ConfigFileReaderAllBrowser.md
+++ b/docs/components/ConfigFileReaderAllBrowser.md
@@ -1,0 +1,71 @@
+# ConfigFileReaderAllBrowser
+
+> [Versione italiana](../../docs/it/components/ConfigFileReaderAllBrowser.md) | [Versión española](../../docs/es/components/ConfigFileReaderAllBrowser.md)
+
+## Overview
+
+`ConfigFileReaderAllBrowser` is a SPOT RFID component that provides a cross-browser file selector for a `config.json` file. Unlike [`ConfigFileReader`](./ConfigFileReader.md), it renders a hidden `<input type="file" accept=".json">` and uses a `ref` to trigger it programmatically when the visible button is clicked — making it compatible with standard desktop and mobile browsers without requiring a native bridge.
+
+On iOS (iPad/iPhone/iPod), an additional instructional message guides the user to save the file to the iOS Files app before selecting it, working around the iOS file-access restrictions.
+
+The component supports an optional entrance animation controlled by `isConfigPage` and `show`.
+
+## Import
+
+```jsx
+import { ConfigFileReaderAllBrowser } from 'thecore-auth';
+```
+
+## Props
+
+| Name | Type | Default | Required | Description |
+|---|---|---|---|---|
+| `handleFileChange` | `function` | — | ✅ | `onChange` handler for the hidden file input. Receives the native `ChangeEvent`. Use `event.target.files[0]` to read the selected file. |
+| `show` | `boolean` | — | — | When `isConfigPage` is `true`, controls the entrance animation: `true` → visible, `false` → hidden with downward offset. |
+| `isConfigPage` | `boolean` | — | — | Enables the animated show/hide behavior driven by `show`. When `false`, the component is always fully visible without animation. |
+
+## CSS Variables
+
+This component does not use SPOT RFID-specific CSS variables. General layout variables from the host application apply.
+
+## Usage
+
+```jsx
+import { ConfigFileReaderAllBrowser } from 'thecore-auth';
+
+function ConfigPage({ isReady }) {
+  const handleFileChange = (event) => {
+    const file = event.target.files[0];
+    if (!file) return;
+
+    const reader = new FileReader();
+    reader.onload = (e) => {
+      try {
+        const config = JSON.parse(e.target.result);
+        console.log('Loaded config:', config);
+      } catch {
+        console.error('Invalid JSON file');
+      }
+    };
+    reader.readAsText(file);
+  };
+
+  return (
+    <div>
+      <ConfigFileReaderAllBrowser
+        isConfigPage={true}
+        show={isReady}
+        handleFileChange={handleFileChange}
+      />
+    </div>
+  );
+}
+```
+
+## Notes
+
+- The iOS detection (`/iPad|iPhone|iPod/.test(navigator.userAgent)`) runs at module evaluation time, not inside the component — it is not reactive to user-agent changes during the session.
+- The hidden `<input type="file">` accepts only `.json` files (`accept=".json"`). The file-type restriction is enforced by the browser UI; `handleFileChange` should still validate the file contents.
+- Use this component instead of [`ConfigFileReader`](./ConfigFileReader.md) when no native WebView bridge is available.
+- The animation behavior is identical to `ConfigFileReader`: active only when `isConfigPage={true}`.
+- The instruction text and iOS guidance message are fixed in Italian as a product requirement.

--- a/docs/components/InputGroup.md
+++ b/docs/components/InputGroup.md
@@ -1,0 +1,86 @@
+# InputGroup
+
+> [Versione italiana](../../docs/it/components/InputGroup.md) | [Versión española](../../docs/es/components/InputGroup.md)
+
+## Overview
+
+`InputGroup` is a SPOT RFID compound input component that pairs a label with a text input field. It operates in two layout modes controlled by `isTag`:
+
+- **Tag mode** (`isTag={true}`) — compact horizontal layout for read-only RFID tag fields (TID, EPC). The input is disabled.
+- **Field mode** (`isTag={false}`, default) — standard layout with a `1/3 + 2/3` label-to-input ratio and generous margin, intended for editable configuration fields.
+
+When an `error` string is provided the input border and focus ring switch to red and the error message appears below the field.
+
+## Import
+
+```jsx
+import { InputGroup } from 'thecore-auth';
+```
+
+## Props
+
+| Name | Type | Default | Required | Description |
+|---|---|---|---|---|
+| `label` | `string` | — | ✅ | Text rendered in the label element |
+| `id` | `string` | — | ✅ | HTML `id` shared between the label (`htmlFor`) and the input |
+| `value` | `string` | `''` | — | Controlled value of the text input |
+| `placeholder` | `string` | `undefined` | — | Placeholder text shown when the input is empty |
+| `isTag` | `boolean` | `false` | — | Enables tag (read-only, compact) mode when `true` |
+| `onChange` | `function` | `undefined` | — | Change handler for the input. Not called in tag mode (input is disabled). |
+| `error` | `string \| null` | `null` | — | Validation error message. Triggers red border and displays the message below the input. |
+
+## CSS Variables
+
+| Variable | Default | Description |
+|---|---|---|
+| `--color-spot-rfid-input-border` | `#f56907` | Border color applied to the input on focus |
+| `--shadow-spot-rfid-input` | `0 0 0 4px var(--color-focus-ring)` | Box shadow applied on focus |
+| `--color-focus-ring` | `#f5690780` | Semi-transparent accent used in the focus shadow |
+| `--color-focus-error` | `rgba(255,0,0,0.5)` | Semi-transparent red used in the error focus shadow |
+| `--shadow-spot-rfid-error` | `0 0 0 4px var(--color-focus-error)` | Box shadow applied when `error` is set |
+
+## Usage
+
+```jsx
+import { useState } from 'react';
+import { InputGroup } from 'thecore-auth';
+
+function ConfigPanel() {
+  const [address, setAddress] = useState('');
+  const [addressError, setAddressError] = useState(null);
+
+  const handleChange = (e) => {
+    setAddress(e.target.value);
+    setAddressError(e.target.value ? null : 'Address is required');
+  };
+
+  return (
+    <div>
+      {/* Editable field */}
+      <InputGroup
+        label="IP Address"
+        id="ip-address"
+        value={address}
+        placeholder="e.g. 192.168.1.1"
+        onChange={handleChange}
+        error={addressError}
+      />
+
+      {/* Read-only tag field (tag mode) */}
+      <InputGroup
+        label="TID"
+        id="tid-a"
+        isTag={true}
+        value="E2003412012345678901234A"
+        placeholder="Read TAG A"
+      />
+    </div>
+  );
+}
+```
+
+## Notes
+
+- In tag mode (`isTag={true}`) the underlying `Input` component receives `disabled={true}`, so `onChange` is never invoked even if provided.
+- The `error` prop only affects visual styling and the message text — form validation logic must be implemented by the parent.
+- `InputGroup` internally composes the library's `Input` and `InputLabel` components. Their individual CSS variables (input background, text color, border radius, padding) also apply here.

--- a/docs/components/SpotRfidHeader.md
+++ b/docs/components/SpotRfidHeader.md
@@ -1,0 +1,76 @@
+# SpotRfidHeader
+
+> [Versione italiana](../../docs/it/components/SpotRfidHeader.md) | [Versión española](../../docs/es/components/SpotRfidHeader.md)
+
+> ⚠️ **Exported as `Header`** from `thecore-auth`. Import with: `import { Header } from 'thecore-auth'`
+
+## Overview
+
+`SpotRfidHeader` is the top navigation bar for SPOT RFID applications. It renders a logo area, the current page title, and a context-aware action button — either a logout button (on the home route when auto-login is disabled) or a back-navigation button (on non-home routes when `showHeaderButton` is enabled).
+
+The header hides itself automatically while the global loading state is active. Logo, page title, and button visibility are all driven by the library's internal contexts — no manual wiring is required beyond passing an optional logo.
+
+## Import
+
+```jsx
+import { Header } from 'thecore-auth';
+```
+
+## Props
+
+| Name | Type | Default | Required | Description |
+|---|---|---|---|---|
+| `Logo` | `React component` | `undefined` | — | SVG component (function) rendered as the header logo. Takes priority over `logo`. |
+| `logo` | `string` | `undefined` | — | URL of an image to render as the header logo. Used when `Logo` is not provided. If neither is supplied, the default MyTrack SVG is used. |
+
+## CSS Variables
+
+| Variable | Default | Description |
+|---|---|---|
+| `--header-height` | `60px` | Height of the header bar |
+| `--width-logo-size` | `48px` | Width of the logo rendered inside the header |
+
+## Usage
+
+```jsx
+import { Header } from 'thecore-auth';
+import CompanyLogo from './assets/company-logo.svg?react';
+
+// Option 1: SVG component (recommended — avoids extra HTTP request)
+function App() {
+  return (
+    <div>
+      <Header Logo={CompanyLogo} />
+      <main>{/* page content */}</main>
+    </div>
+  );
+}
+
+// Option 2: image URL
+function App() {
+  return (
+    <div>
+      <Header logo="/assets/company-logo.png" />
+      <main>{/* page content */}</main>
+    </div>
+  );
+}
+
+// Option 3: default logo (no props needed)
+function App() {
+  return (
+    <div>
+      <Header />
+      <main>{/* page content */}</main>
+    </div>
+  );
+}
+```
+
+## Notes
+
+- The logout button appears only when `autoLogin` is `false` (from `useConfig`) **and** the current route matches `home/:id`.
+- The back button appears only when the current route does **not** match `home/:id` and `showHeaderButton` is `true` (from `useConfig`).
+- The back button calls `navigate(-1)` from React Router — it relies on browser history being available.
+- The page title displayed in the center is derived from `configRoutes` (from `useConfig`); it falls back to `firstPrivateTitle` when no route matches.
+- Requires `AuthProvider`, `AlertProvider`, `ConfigProvider`, and `LoadingProvider` to be present in the tree.

--- a/docs/es/components/CardInputRange.md
+++ b/docs/es/components/CardInputRange.md
@@ -1,0 +1,74 @@
+# CardInputRange
+
+> [English](../../../docs/components/CardInputRange.md) | [Versione italiana](../../it/components/CardInputRange.md)
+
+## Descripción general
+
+`CardInputRange` es un componente card SPOT RFID para configurar la potencia de transmisión del lector RFID. Renderiza un slider estilizado con un tooltip flotante que sigue el valor actual y un botón guardar que confirma el valor seleccionado.
+
+La card se anima desde abajo en función de la prop `show`. La posición del tooltip se calcula como porcentaje del rango para que siempre se alinee con el cursor del slider.
+
+## Import
+
+```jsx
+import { CardInputRange } from 'thecore-auth';
+```
+
+## Props
+
+| Nombre | Tipo | Default | Requerido | Descripción |
+|---|---|---|---|---|
+| `minReadingPower` | `number` | — | ✅ | Valor mínimo del slider de potencia |
+| `maxReadingPower` | `number` | — | ✅ | Valor máximo del slider de potencia |
+| `stepRangePower` | `number` | — | ✅ | Incremento del paso del slider |
+| `rangeValue` | `number` | — | ✅ | Valor controlado actual del slider |
+| `setRangeValue` | `function` | — | ✅ | Setter de estado llamado con el nuevo valor numérico cuando cambia el slider |
+| `show` | `boolean` | — | ✅ | Controla la animación de entrada — `true` hace visible la card, `false` la oculta |
+| `handleClick` | `function` | — | ✅ | Callback invocada con el `rangeValue` actual al hacer clic en el botón guardar |
+
+## Variables CSS
+
+| Variable | Default | Descripción |
+|---|---|---|
+| `--color-primary-accent` | `#f56907` | Color accent usado para el cursor y el track del slider |
+| `--color-save-button` | `#16A34A` | Color de fondo del botón guardar |
+
+## Uso
+
+```jsx
+import { useState } from 'react';
+import { CardInputRange } from 'thecore-auth';
+
+function PowerConfig() {
+  const [power, setPower] = useState(20);
+  const [visible, setVisible] = useState(false);
+
+  const handleSave = (value) => {
+    console.log('Saving power level:', value);
+    // send to RFID reader API
+  };
+
+  return (
+    <div>
+      <button onClick={() => setVisible(true)}>Configurar potencia</button>
+
+      <CardInputRange
+        minReadingPower={0}
+        maxReadingPower={30}
+        stepRangePower={1}
+        rangeValue={power}
+        setRangeValue={setPower}
+        show={visible}
+        handleClick={handleSave}
+      />
+    </div>
+  );
+}
+```
+
+## Notas
+
+- `setRangeValue` se llama con un `Number` (vía `Number(e.target.value)`) — el estado padre debe aceptar un número, no una cadena.
+- `handleClick` recibe el `rangeValue` actual como primer argumento; no recibe el evento nativo.
+- La posición del tooltip flotante puede desviarse ligeramente en los extremos del slider debido al ancho del cursor del navegador — es una limitación cosmética conocida del posicionamiento porcentual.
+- El slider usa la clase Tailwind `accent-primary-accent` que mapea a `--color-primary-accent`; sobrescribir esta variable cambia el color del cursor y el track relleno.

--- a/docs/es/components/CardInputTag.md
+++ b/docs/es/components/CardInputTag.md
@@ -1,0 +1,80 @@
+# CardInputTag
+
+> [English](../../../docs/components/CardInputTag.md) | [Versione italiana](../../it/components/CardInputTag.md)
+
+## Descripción general
+
+`CardInputTag` es un componente card SPOT RFID que muestra los valores TID y EPC de un único tag RFID. Renderiza dos campos `InputGroup` de solo lectura y un botón de escritura opcional. La card se anima desde abajo mediante una transición CSS controlada por `showTag`.
+
+El botón de escritura se deshabilita automáticamente cuando tanto `valueTID` como `valueEPC` están vacíos, evitando escrituras antes de que el lector haya devuelto datos.
+
+## Import
+
+```jsx
+import { CardInputTag } from 'thecore-auth';
+```
+
+## Props
+
+| Nombre | Tipo | Default | Requerido | Descripción |
+|---|---|---|---|---|
+| `title` | `string` | — | ✅ | Texto del título de la card (ej. `'TAG A'`, `'TAG B'`). También se usa en el placeholder. El valor `'TAG B'` aplica un `delay-200` adicional a la animación de entrada. |
+| `showTag` | `boolean` | — | ✅ | Controla la animación de entrada — `true` hace visible la card, `false` la oculta con desplazamiento hacia abajo. |
+| `value` | `object` | `undefined` | — | Objeto con los datos del tag. Estructura: `{ valueTID: string, valueEPC: string }`. |
+| `tag` | `string` | `undefined` | — | Sufijo añadido a los atributos `id` de los inputs (ej. `'a'` → ids se convierten en `tid-a`, `epc-a`). Omitir cuando se renderiza una sola card. |
+| `showButton` | `boolean` | — | ✅ | Cuando es `true`, el botón de escritura está **oculto**. Cuando es `false`, el botón es visible. |
+| `handleClick` | `function` | `undefined` | — | Callback invocada al hacer clic en el botón de escritura. |
+
+## Variables CSS
+
+| Variable | Default | Descripción |
+|---|---|---|
+| `--color-write-button` | `#0284C7` | Color de fondo del botón de escritura |
+
+## Uso
+
+```jsx
+import { useState } from 'react';
+import { CardInputTag } from 'thecore-auth';
+
+function TagPanel() {
+  const [visible, setVisible] = useState(false);
+  const [tagData, setTagData] = useState({ valueTID: '', valueEPC: '' });
+
+  const handleWrite = () => {
+    console.log('Writing tag:', tagData);
+  };
+
+  return (
+    <div>
+      <button onClick={() => setVisible(true)}>Iniciar lectura</button>
+
+      <CardInputTag
+        title="TAG A"
+        showTag={visible}
+        value={tagData}
+        tag="a"
+        showButton={false}
+        handleClick={handleWrite}
+      />
+
+      {/* Second card with staggered animation delay */}
+      <CardInputTag
+        title="TAG B"
+        showTag={visible}
+        value={{ valueTID: 'E2003412AABBCCDD', valueEPC: '300833B2DDD9014000000000' }}
+        tag="b"
+        showButton={true}
+        handleClick={() => {}}
+      />
+    </div>
+  );
+}
+```
+
+## Notas
+
+- El botón de escritura está deshabilitado (no oculto) cuando tanto `value?.valueTID` como `value?.valueEPC` son falsy. Se habilita en cuanto se llena uno de los campos.
+- `showButton={true}` **oculta** completamente el botón (la prop está invertida — controla si ocultarlo, no si mostrarlo).
+- La comprobación del título `'TAG B'` es un delay hardcoded para diseños de dos cards escalonadas; para otros títulos no se aplica ningún delay.
+- `tag` sirve para hacer únicos los atributos `id` de los inputs cuando varias cards aparecen en la misma página. Omitirlo solo cuando se renderiza una sola card.

--- a/docs/es/components/ConfigFileReader.md
+++ b/docs/es/components/ConfigFileReader.md
@@ -1,0 +1,56 @@
+# ConfigFileReader
+
+> [English](../../../docs/components/ConfigFileReader.md) | [Versione italiana](../../it/components/ConfigFileReader.md)
+
+## Descripción general
+
+`ConfigFileReader` es un componente SPOT RFID que muestra un texto guía y un botón para seleccionar un archivo `config.json`. Está diseñado para entornos donde la integración nativa del file-picker se proporciona externamente (ej. un bridge WebView o una API de sistema de archivos personalizada) — el componente solo renderiza el botón y delega la apertura efectiva del archivo a `handleSelectFile`.
+
+Soporta una animación de entrada opcional controlada por la combinación de `isConfigPage` y `show`.
+
+## Import
+
+```jsx
+import { ConfigFileReader } from 'thecore-auth';
+```
+
+## Props
+
+| Nombre | Tipo | Default | Requerido | Descripción |
+|---|---|---|---|---|
+| `handleSelectFile` | `function` | — | ✅ | Llamada al hacer clic en el botón "Seleziona file". Responsable de abrir el file picker o activar el bridge nativo. |
+| `show` | `boolean` | — | — | Cuando `isConfigPage` es `true`, controla la animación de entrada: `true` → visible, `false` → oculto con desplazamiento hacia abajo. |
+| `isConfigPage` | `boolean` | — | — | Habilita el comportamiento animado show/hide guiado por `show`. Cuando es `false`, el componente siempre es completamente visible sin animación. |
+
+## Variables CSS
+
+Este componente no usa variables CSS específicas de SPOT RFID. Se aplican las variables de layout generales de la aplicación anfitriona.
+
+## Uso
+
+```jsx
+import { ConfigFileReader } from 'thecore-auth';
+
+function ConfigPage({ isReady }) {
+  const handleSelectFile = () => {
+    // Trigger a WebView bridge call or a custom native file dialog
+    window.NativeBridge?.openFilePicker('application/json');
+  };
+
+  return (
+    <div>
+      <ConfigFileReader
+        isConfigPage={true}
+        show={isReady}
+        handleSelectFile={handleSelectFile}
+      />
+    </div>
+  );
+}
+```
+
+## Notas
+
+- Este componente **no** renderiza un `<input type="file">` oculto. La selección de archivo está completamente delegada a `handleSelectFile` — usar [`ConfigFileReaderAllBrowser`](./ConfigFileReaderAllBrowser.md) para el comportamiento estándar del file-picker del navegador.
+- La animación solo está activa cuando `isConfigPage={true}`. Cuando `isConfigPage` es `false` u omitido, `show` no tiene efecto.
+- El texto de instrucción ("Seleziona il file **config.json**…") está fijo en italiano como requisito de producto.

--- a/docs/es/components/ConfigFileReaderAllBrowser.md
+++ b/docs/es/components/ConfigFileReaderAllBrowser.md
@@ -1,0 +1,71 @@
+# ConfigFileReaderAllBrowser
+
+> [English](../../../docs/components/ConfigFileReaderAllBrowser.md) | [Versione italiana](../../it/components/ConfigFileReaderAllBrowser.md)
+
+## Descripción general
+
+`ConfigFileReaderAllBrowser` es un componente SPOT RFID que proporciona un selector de archivos cross-browser para un archivo `config.json`. A diferencia de [`ConfigFileReader`](./ConfigFileReader.md), renderiza un `<input type="file" accept=".json">` oculto y usa un `ref` para activarlo programáticamente al hacer clic en el botón visible — haciéndolo compatible con navegadores de escritorio y móviles estándar sin requerir un bridge nativo.
+
+En iOS (iPad/iPhone/iPod), un mensaje de instrucción adicional guía al usuario a guardar el archivo en la app Archivos de iOS antes de seleccionarlo, sorteando las restricciones de acceso a archivos de iOS.
+
+Soporta una animación de entrada opcional controlada por `isConfigPage` y `show`.
+
+## Import
+
+```jsx
+import { ConfigFileReaderAllBrowser } from 'thecore-auth';
+```
+
+## Props
+
+| Nombre | Tipo | Default | Requerido | Descripción |
+|---|---|---|---|---|
+| `handleFileChange` | `function` | — | ✅ | Handler `onChange` para el input file oculto. Recibe el `ChangeEvent` nativo. Usar `event.target.files[0]` para leer el archivo seleccionado. |
+| `show` | `boolean` | — | — | Cuando `isConfigPage` es `true`, controla la animación de entrada: `true` → visible, `false` → oculto con desplazamiento hacia abajo. |
+| `isConfigPage` | `boolean` | — | — | Habilita el comportamiento animado show/hide guiado por `show`. Cuando es `false`, el componente siempre es completamente visible sin animación. |
+
+## Variables CSS
+
+Este componente no usa variables CSS específicas de SPOT RFID. Se aplican las variables de layout generales de la aplicación anfitriona.
+
+## Uso
+
+```jsx
+import { ConfigFileReaderAllBrowser } from 'thecore-auth';
+
+function ConfigPage({ isReady }) {
+  const handleFileChange = (event) => {
+    const file = event.target.files[0];
+    if (!file) return;
+
+    const reader = new FileReader();
+    reader.onload = (e) => {
+      try {
+        const config = JSON.parse(e.target.result);
+        console.log('Loaded config:', config);
+      } catch {
+        console.error('Invalid JSON file');
+      }
+    };
+    reader.readAsText(file);
+  };
+
+  return (
+    <div>
+      <ConfigFileReaderAllBrowser
+        isConfigPage={true}
+        show={isReady}
+        handleFileChange={handleFileChange}
+      />
+    </div>
+  );
+}
+```
+
+## Notas
+
+- La detección de iOS (`/iPad|iPhone|iPod/.test(navigator.userAgent)`) se ejecuta en el momento de la evaluación del módulo, no dentro del componente — no es reactiva a cambios del user-agent durante la sesión.
+- El `<input type="file">` oculto acepta solo archivos `.json` (`accept=".json"`). La restricción del tipo de archivo la aplica la UI del navegador; `handleFileChange` debería igualmente validar el contenido del archivo.
+- Usar este componente en lugar de [`ConfigFileReader`](./ConfigFileReader.md) cuando no hay un bridge WebView nativo disponible.
+- El comportamiento de la animación es idéntico a `ConfigFileReader`: activo solo cuando `isConfigPage={true}`.
+- El texto de instrucción y el mensaje guía de iOS están fijos en italiano como requisito de producto.

--- a/docs/es/components/InputGroup.md
+++ b/docs/es/components/InputGroup.md
@@ -1,0 +1,86 @@
+# InputGroup
+
+> [English](../../../docs/components/InputGroup.md) | [Versione italiana](../../it/components/InputGroup.md)
+
+## Descripción general
+
+`InputGroup` es un componente SPOT RFID compuesto que combina una etiqueta con un campo de texto. Opera en dos modos de diseño controlados por `isTag`:
+
+- **Modo tag** (`isTag={true}`) — diseño horizontal compacto para campos RFID de solo lectura (TID, EPC). El input está deshabilitado.
+- **Modo campo** (`isTag={false}`, por defecto) — diseño estándar con proporción etiqueta-input `1/3 + 2/3` y margen generoso, para campos de configuración editables.
+
+Cuando se proporciona una cadena `error`, el borde del input y el anillo de foco se vuelven rojos y el mensaje de error aparece debajo del campo.
+
+## Import
+
+```jsx
+import { InputGroup } from 'thecore-auth';
+```
+
+## Props
+
+| Nombre | Tipo | Default | Requerido | Descripción |
+|---|---|---|---|---|
+| `label` | `string` | — | ✅ | Texto renderizado en la etiqueta |
+| `id` | `string` | — | ✅ | HTML `id` compartido entre la etiqueta (`htmlFor`) y el input |
+| `value` | `string` | `''` | — | Valor controlado del campo de texto |
+| `placeholder` | `string` | `undefined` | — | Texto placeholder mostrado cuando el campo está vacío |
+| `isTag` | `boolean` | `false` | — | Activa el modo tag (solo lectura, compacto) cuando es `true` |
+| `onChange` | `function` | `undefined` | — | Handler para el cambio de valor. No se llama en modo tag (input deshabilitado). |
+| `error` | `string \| null` | `null` | — | Mensaje de error de validación. Activa el borde rojo y muestra el mensaje debajo del input. |
+
+## Variables CSS
+
+| Variable | Default | Descripción |
+|---|---|---|
+| `--color-spot-rfid-input-border` | `#f56907` | Color del borde aplicado al input en foco |
+| `--shadow-spot-rfid-input` | `0 0 0 4px var(--color-focus-ring)` | Box shadow en foco |
+| `--color-focus-ring` | `#f5690780` | Color semi-transparente del anillo de foco |
+| `--color-focus-error` | `rgba(255,0,0,0.5)` | Rojo semi-transparente para el anillo de foco en error |
+| `--shadow-spot-rfid-error` | `0 0 0 4px var(--color-focus-error)` | Box shadow cuando `error` está definido |
+
+## Uso
+
+```jsx
+import { useState } from 'react';
+import { InputGroup } from 'thecore-auth';
+
+function ConfigPanel() {
+  const [address, setAddress] = useState('');
+  const [addressError, setAddressError] = useState(null);
+
+  const handleChange = (e) => {
+    setAddress(e.target.value);
+    setAddressError(e.target.value ? null : 'Address is required');
+  };
+
+  return (
+    <div>
+      {/* Editable field */}
+      <InputGroup
+        label="Dirección IP"
+        id="ip-address"
+        value={address}
+        placeholder="ej. 192.168.1.1"
+        onChange={handleChange}
+        error={addressError}
+      />
+
+      {/* Read-only tag field (tag mode) */}
+      <InputGroup
+        label="TID"
+        id="tid-a"
+        isTag={true}
+        value="E2003412012345678901234A"
+        placeholder="Leer TAG A"
+      />
+    </div>
+  );
+}
+```
+
+## Notas
+
+- En modo tag (`isTag={true}`), el componente `Input` subyacente recibe `disabled={true}`, por lo que `onChange` nunca se invoca aunque se proporcione.
+- La prop `error` solo afecta el estilo visual y el texto del mensaje — la lógica de validación debe implementarla el componente padre.
+- `InputGroup` compone internamente los componentes `Input` e `InputLabel` de la librería. Sus variables CSS individuales (fondo, color de texto, border radius, padding) también se aplican aquí.

--- a/docs/es/components/SpotRfidHeader.md
+++ b/docs/es/components/SpotRfidHeader.md
@@ -1,0 +1,76 @@
+# SpotRfidHeader
+
+> [English](../../../docs/components/SpotRfidHeader.md) | [Versione italiana](../../it/components/SpotRfidHeader.md)
+
+> ⚠️ **Exportado como `Header`** desde `thecore-auth`. Importar con: `import { Header } from 'thecore-auth'`
+
+## Descripción general
+
+`SpotRfidHeader` es la barra de navegación superior para aplicaciones SPOT RFID. Muestra un área de logo, el título de la página actual y un botón contextual — logout (en la ruta home cuando el inicio de sesión automático está deshabilitado) o navegación hacia atrás (en rutas no-home cuando `showHeaderButton` está activado).
+
+El header se oculta automáticamente mientras el estado de carga global está activo. El logo, el título y la visibilidad del botón están gestionados por los contextos internos de la librería.
+
+## Import
+
+```jsx
+import { Header } from 'thecore-auth';
+```
+
+## Props
+
+| Nombre | Tipo | Default | Requerido | Descripción |
+|---|---|---|---|---|
+| `Logo` | `React component` | `undefined` | — | Componente SVG (función) renderizado como logo del header. Tiene prioridad sobre `logo`. |
+| `logo` | `string` | `undefined` | — | URL de una imagen a renderizar como logo. Se usa cuando no se proporciona `Logo`. Si no se proporciona ninguno, se usa el SVG MyTrack predeterminado. |
+
+## Variables CSS
+
+| Variable | Default | Descripción |
+|---|---|---|
+| `--header-height` | `60px` | Altura de la barra del header |
+| `--width-logo-size` | `48px` | Ancho del logo dentro del header |
+
+## Uso
+
+```jsx
+import { Header } from 'thecore-auth';
+import CompanyLogo from './assets/company-logo.svg?react';
+
+// Option 1: SVG component (recommended — avoids extra HTTP request)
+function App() {
+  return (
+    <div>
+      <Header Logo={CompanyLogo} />
+      <main>{/* contenido de la página */}</main>
+    </div>
+  );
+}
+
+// Option 2: image URL
+function App() {
+  return (
+    <div>
+      <Header logo="/assets/company-logo.png" />
+      <main>{/* contenido de la página */}</main>
+    </div>
+  );
+}
+
+// Option 3: default logo (no props needed)
+function App() {
+  return (
+    <div>
+      <Header />
+      <main>{/* contenido de la página */}</main>
+    </div>
+  );
+}
+```
+
+## Notas
+
+- El botón de logout aparece solo cuando `autoLogin` es `false` (desde `useConfig`) **y** la ruta actual coincide con `home/:id`.
+- El botón de retroceso aparece solo cuando la ruta actual **no** coincide con `home/:id` y `showHeaderButton` es `true` (desde `useConfig`).
+- El botón de retroceso llama a `navigate(-1)` de React Router — depende de que el historial del navegador esté disponible.
+- El título central proviene de `configRoutes` (vía `useConfig`); si ninguna ruta coincide, se usa `firstPrivateTitle`.
+- Requiere `AuthProvider`, `AlertProvider`, `ConfigProvider` y `LoadingProvider` en el árbol de componentes.

--- a/docs/it/components/CardInputRange.md
+++ b/docs/it/components/CardInputRange.md
@@ -1,0 +1,74 @@
+# CardInputRange
+
+> [English](../../../docs/components/CardInputRange.md) | [Versión española](../../es/components/CardInputRange.md)
+
+## Panoramica
+
+`CardInputRange` è un componente card SPOT RFID per la configurazione della potenza di trasmissione del lettore RFID. Renderizza uno slider con un tooltip flottante che segue il valore corrente e un pulsante salva che conferma il valore selezionato.
+
+La card si anima dal basso in base alla prop `show`. La posizione del tooltip è calcolata come percentuale del range in modo che si allinei sempre al cursore dello slider.
+
+## Import
+
+```jsx
+import { CardInputRange } from 'thecore-auth';
+```
+
+## Props
+
+| Nome | Tipo | Default | Obbligatorio | Descrizione |
+|---|---|---|---|---|
+| `minReadingPower` | `number` | — | ✅ | Valore minimo dello slider di potenza |
+| `maxReadingPower` | `number` | — | ✅ | Valore massimo dello slider di potenza |
+| `stepRangePower` | `number` | — | ✅ | Incremento del passo dello slider |
+| `rangeValue` | `number` | — | ✅ | Valore controllato corrente dello slider |
+| `setRangeValue` | `function` | — | ✅ | Setter di stato chiamato con il nuovo valore numerico quando lo slider cambia |
+| `show` | `boolean` | — | ✅ | Controlla l'animazione di ingresso — `true` rende la card visibile, `false` la nasconde |
+| `handleClick` | `function` | — | ✅ | Callback invocata con il `rangeValue` corrente al click del pulsante salva |
+
+## Variabili CSS
+
+| Variabile | Default | Descrizione |
+|---|---|---|
+| `--color-primary-accent` | `#f56907` | Colore accent usato per il cursore e il tracciato dello slider |
+| `--color-save-button` | `#16A34A` | Colore di sfondo del pulsante salva |
+
+## Utilizzo
+
+```jsx
+import { useState } from 'react';
+import { CardInputRange } from 'thecore-auth';
+
+function PowerConfig() {
+  const [power, setPower] = useState(20);
+  const [visible, setVisible] = useState(false);
+
+  const handleSave = (value) => {
+    console.log('Saving power level:', value);
+    // send to RFID reader API
+  };
+
+  return (
+    <div>
+      <button onClick={() => setVisible(true)}>Configura potenza</button>
+
+      <CardInputRange
+        minReadingPower={0}
+        maxReadingPower={30}
+        stepRangePower={1}
+        rangeValue={power}
+        setRangeValue={setPower}
+        show={visible}
+        handleClick={handleSave}
+      />
+    </div>
+  );
+}
+```
+
+## Note
+
+- `setRangeValue` viene chiamato con un `Number` (tramite `Number(e.target.value)`) — lo stato padre deve accettare un numero, non una stringa.
+- `handleClick` riceve il `rangeValue` corrente come primo argomento; non riceve l'evento nativo.
+- La posizione del tooltip flottante può scartare leggermente agli estremi dello slider a causa della larghezza del cursore del browser — è una limitazione cosmetica nota del posizionamento percentuale.
+- Lo slider usa la classe Tailwind `accent-primary-accent` che mappa su `--color-primary-accent`; sovrascrivere questa variabile cambia il colore del cursore e del tracciato riempito.

--- a/docs/it/components/CardInputTag.md
+++ b/docs/it/components/CardInputTag.md
@@ -1,0 +1,80 @@
+# CardInputTag
+
+> [English](../../../docs/components/CardInputTag.md) | [Versión española](../../es/components/CardInputTag.md)
+
+## Panoramica
+
+`CardInputTag` è un componente card SPOT RFID che mostra i valori TID ed EPC di un singolo tag RFID. Renderizza due campi `InputGroup` in sola lettura e un pulsante di scrittura opzionale. La card si anima dal basso grazie a una transizione CSS controllata da `showTag`.
+
+Il pulsante di scrittura viene disabilitato automaticamente quando sia `valueTID` che `valueEPC` sono vuoti, impedendo scritture prima che il lettore abbia restituito dati.
+
+## Import
+
+```jsx
+import { CardInputTag } from 'thecore-auth';
+```
+
+## Props
+
+| Nome | Tipo | Default | Obbligatorio | Descrizione |
+|---|---|---|---|---|
+| `title` | `string` | — | ✅ | Testo del titolo della card (es. `'TAG A'`, `'TAG B'`). Usato anche nel testo del placeholder. Il valore `'TAG B'` applica un `delay-200` aggiuntivo all'animazione di ingresso. |
+| `showTag` | `boolean` | — | ✅ | Controlla l'animazione di ingresso — `true` rende la card visibile, `false` la nasconde con offset verso il basso. |
+| `value` | `object` | `undefined` | — | Oggetto con i dati del tag. Struttura: `{ valueTID: string, valueEPC: string }`. |
+| `tag` | `string` | `undefined` | — | Suffisso aggiunto agli attributi `id` degli input (es. `'a'` → id diventano `tid-a`, `epc-a`). Omettere quando si renderizza una sola card. |
+| `showButton` | `boolean` | — | ✅ | Quando `true`, il pulsante di scrittura è **nascosto**. Quando `false`, il pulsante è visibile. |
+| `handleClick` | `function` | `undefined` | — | Callback invocata al click del pulsante di scrittura. |
+
+## Variabili CSS
+
+| Variabile | Default | Descrizione |
+|---|---|---|
+| `--color-write-button` | `#0284C7` | Colore di sfondo del pulsante di scrittura |
+
+## Utilizzo
+
+```jsx
+import { useState } from 'react';
+import { CardInputTag } from 'thecore-auth';
+
+function TagPanel() {
+  const [visible, setVisible] = useState(false);
+  const [tagData, setTagData] = useState({ valueTID: '', valueEPC: '' });
+
+  const handleWrite = () => {
+    console.log('Writing tag:', tagData);
+  };
+
+  return (
+    <div>
+      <button onClick={() => setVisible(true)}>Inizia lettura</button>
+
+      <CardInputTag
+        title="TAG A"
+        showTag={visible}
+        value={tagData}
+        tag="a"
+        showButton={false}
+        handleClick={handleWrite}
+      />
+
+      {/* Second card with staggered animation delay */}
+      <CardInputTag
+        title="TAG B"
+        showTag={visible}
+        value={{ valueTID: 'E2003412AABBCCDD', valueEPC: '300833B2DDD9014000000000' }}
+        tag="b"
+        showButton={true}
+        handleClick={() => {}}
+      />
+    </div>
+  );
+}
+```
+
+## Note
+
+- Il pulsante di scrittura è disabilitato (non nascosto) quando sia `value?.valueTID` che `value?.valueEPC` sono falsy. Si abilita appena uno dei due campi è popolato.
+- `showButton={true}` **nasconde** completamente il pulsante (la prop è invertita — controlla se nasconderlo, non se mostrarlo).
+- Il controllo sul titolo `'TAG B'` è un delay hardcoded per layout a due card sfasate; per altri titoli non viene applicato alcun delay.
+- `tag` serve a rendere univoci gli attributi `id` degli input quando più card appaiono sulla stessa pagina. Ometterlo solo con una sola card renderizzata.

--- a/docs/it/components/ConfigFileReader.md
+++ b/docs/it/components/ConfigFileReader.md
@@ -1,0 +1,56 @@
+# ConfigFileReader
+
+> [English](../../../docs/components/ConfigFileReader.md) | [Versión española](../../es/components/ConfigFileReader.md)
+
+## Panoramica
+
+`ConfigFileReader` è un componente SPOT RFID che mostra un testo guida e un pulsante per selezionare un file `config.json`. È progettato per ambienti in cui l'integrazione nativa del file-picker è fornita esternamente (es. un bridge WebView o una API file-system personalizzata) — il componente renderizza solo il pulsante e delega l'apertura effettiva del file a `handleSelectFile`.
+
+Supporta un'animazione di ingresso opzionale controllata dalla combinazione di `isConfigPage` e `show`.
+
+## Import
+
+```jsx
+import { ConfigFileReader } from 'thecore-auth';
+```
+
+## Props
+
+| Nome | Tipo | Default | Obbligatorio | Descrizione |
+|---|---|---|---|---|
+| `handleSelectFile` | `function` | — | ✅ | Chiamata al click del pulsante "Seleziona file". Responsabile dell'apertura del file picker o del trigger del bridge nativo. |
+| `show` | `boolean` | — | — | Quando `isConfigPage` è `true`, controlla l'animazione di ingresso: `true` → visibile, `false` → nascosto con offset verso il basso. |
+| `isConfigPage` | `boolean` | — | — | Abilita il comportamento animato show/hide guidato da `show`. Quando `false`, il componente è sempre completamente visibile senza animazione. |
+
+## Variabili CSS
+
+Questo componente non usa variabili CSS specifiche per SPOT RFID. Si applicano le variabili di layout generali dell'applicazione ospite.
+
+## Utilizzo
+
+```jsx
+import { ConfigFileReader } from 'thecore-auth';
+
+function ConfigPage({ isReady }) {
+  const handleSelectFile = () => {
+    // Trigger a WebView bridge call or a custom native file dialog
+    window.NativeBridge?.openFilePicker('application/json');
+  };
+
+  return (
+    <div>
+      <ConfigFileReader
+        isConfigPage={true}
+        show={isReady}
+        handleSelectFile={handleSelectFile}
+      />
+    </div>
+  );
+}
+```
+
+## Note
+
+- Questo componente **non** renderizza un `<input type="file">` nascosto. La selezione del file è completamente delegata a `handleSelectFile` — usare [`ConfigFileReaderAllBrowser`](./ConfigFileReaderAllBrowser.md) per il comportamento standard del file-picker del browser.
+- L'animazione è attiva solo quando `isConfigPage={true}`. Quando `isConfigPage` è `false` o omesso, `show` non ha effetto.
+- Il testo istruzione ("Seleziona il file **config.json**…") è fisso in italiano come requisito di prodotto.

--- a/docs/it/components/ConfigFileReaderAllBrowser.md
+++ b/docs/it/components/ConfigFileReaderAllBrowser.md
@@ -1,0 +1,71 @@
+# ConfigFileReaderAllBrowser
+
+> [English](../../../docs/components/ConfigFileReaderAllBrowser.md) | [Versión española](../../es/components/ConfigFileReaderAllBrowser.md)
+
+## Panoramica
+
+`ConfigFileReaderAllBrowser` è un componente SPOT RFID che fornisce un selettore di file cross-browser per un file `config.json`. A differenza di [`ConfigFileReader`](./ConfigFileReader.md), renderizza un `<input type="file" accept=".json">` nascosto e usa un `ref` per attivarlo programmaticamente al click del pulsante visibile — rendendolo compatibile con i browser desktop e mobile standard senza richiedere un bridge nativo.
+
+Su iOS (iPad/iPhone/iPod), un messaggio istruzionale aggiuntivo guida l'utente a salvare il file nell'app File di iOS prima di selezionarlo, aggirando le restrizioni di accesso ai file di iOS.
+
+Supporta un'animazione di ingresso opzionale controllata da `isConfigPage` e `show`.
+
+## Import
+
+```jsx
+import { ConfigFileReaderAllBrowser } from 'thecore-auth';
+```
+
+## Props
+
+| Nome | Tipo | Default | Obbligatorio | Descrizione |
+|---|---|---|---|---|
+| `handleFileChange` | `function` | — | ✅ | Handler `onChange` per l'input file nascosto. Riceve il `ChangeEvent` nativo. Usare `event.target.files[0]` per leggere il file selezionato. |
+| `show` | `boolean` | — | — | Quando `isConfigPage` è `true`, controlla l'animazione di ingresso: `true` → visibile, `false` → nascosto con offset verso il basso. |
+| `isConfigPage` | `boolean` | — | — | Abilita il comportamento animato show/hide guidato da `show`. Quando `false`, il componente è sempre completamente visibile senza animazione. |
+
+## Variabili CSS
+
+Questo componente non usa variabili CSS specifiche per SPOT RFID. Si applicano le variabili di layout generali dell'applicazione ospite.
+
+## Utilizzo
+
+```jsx
+import { ConfigFileReaderAllBrowser } from 'thecore-auth';
+
+function ConfigPage({ isReady }) {
+  const handleFileChange = (event) => {
+    const file = event.target.files[0];
+    if (!file) return;
+
+    const reader = new FileReader();
+    reader.onload = (e) => {
+      try {
+        const config = JSON.parse(e.target.result);
+        console.log('Loaded config:', config);
+      } catch {
+        console.error('Invalid JSON file');
+      }
+    };
+    reader.readAsText(file);
+  };
+
+  return (
+    <div>
+      <ConfigFileReaderAllBrowser
+        isConfigPage={true}
+        show={isReady}
+        handleFileChange={handleFileChange}
+      />
+    </div>
+  );
+}
+```
+
+## Note
+
+- Il rilevamento iOS (`/iPad|iPhone|iPod/.test(navigator.userAgent)`) viene eseguito al momento della valutazione del modulo, non all'interno del componente — non è reattivo ai cambiamenti dello user-agent durante la sessione.
+- L'`<input type="file">` nascosto accetta solo file `.json` (`accept=".json"`). La restrizione del tipo di file è applicata dalla UI del browser; `handleFileChange` dovrebbe comunque validare il contenuto del file.
+- Usare questo componente invece di [`ConfigFileReader`](./ConfigFileReader.md) quando non è disponibile un bridge WebView nativo.
+- Il comportamento dell'animazione è identico a `ConfigFileReader`: attivo solo quando `isConfigPage={true}`.
+- Il testo istruzione e il messaggio guida iOS sono fissi in italiano come requisito di prodotto.

--- a/docs/it/components/InputGroup.md
+++ b/docs/it/components/InputGroup.md
@@ -1,0 +1,86 @@
+# InputGroup
+
+> [English](../../../docs/components/InputGroup.md) | [Versión española](../../es/components/InputGroup.md)
+
+## Panoramica
+
+`InputGroup` è un componente SPOT RFID che abbina un'etichetta a un campo di testo. Opera in due modalità di layout controllate da `isTag`:
+
+- **Modalità tag** (`isTag={true}`) — layout orizzontale compatto per campi RFID in sola lettura (TID, EPC). L'input è disabilitato.
+- **Modalità campo** (`isTag={false}`, default) — layout standard con rapporto etichetta-input `1/3 + 2/3` e margine generoso, per campi di configurazione editabili.
+
+Quando è fornita una stringa `error`, il bordo dell'input e l'anello di focus diventano rossi e il messaggio di errore appare sotto il campo.
+
+## Import
+
+```jsx
+import { InputGroup } from 'thecore-auth';
+```
+
+## Props
+
+| Nome | Tipo | Default | Obbligatorio | Descrizione |
+|---|---|---|---|---|
+| `label` | `string` | — | ✅ | Testo renderizzato nell'etichetta |
+| `id` | `string` | — | ✅ | HTML `id` condiviso tra etichetta (`htmlFor`) e input |
+| `value` | `string` | `''` | — | Valore controllato del campo di testo |
+| `placeholder` | `string` | `undefined` | — | Testo placeholder mostrato quando il campo è vuoto |
+| `isTag` | `boolean` | `false` | — | Attiva la modalità tag (sola lettura, compatta) quando `true` |
+| `onChange` | `function` | `undefined` | — | Handler per il cambio valore. Non viene chiamato in modalità tag (input disabilitato). |
+| `error` | `string \| null` | `null` | — | Messaggio di errore di validazione. Attiva il bordo rosso e mostra il messaggio sotto l'input. |
+
+## Variabili CSS
+
+| Variabile | Default | Descrizione |
+|---|---|---|
+| `--color-spot-rfid-input-border` | `#f56907` | Colore del bordo applicato all'input in focus |
+| `--shadow-spot-rfid-input` | `0 0 0 4px var(--color-focus-ring)` | Box shadow in focus |
+| `--color-focus-ring` | `#f5690780` | Colore semi-trasparente dell'anello di focus |
+| `--color-focus-error` | `rgba(255,0,0,0.5)` | Rosso semi-trasparente per l'anello di focus in errore |
+| `--shadow-spot-rfid-error` | `0 0 0 4px var(--color-focus-error)` | Box shadow quando `error` è impostato |
+
+## Utilizzo
+
+```jsx
+import { useState } from 'react';
+import { InputGroup } from 'thecore-auth';
+
+function ConfigPanel() {
+  const [address, setAddress] = useState('');
+  const [addressError, setAddressError] = useState(null);
+
+  const handleChange = (e) => {
+    setAddress(e.target.value);
+    setAddressError(e.target.value ? null : 'Address is required');
+  };
+
+  return (
+    <div>
+      {/* Editable field */}
+      <InputGroup
+        label="Indirizzo IP"
+        id="ip-address"
+        value={address}
+        placeholder="es. 192.168.1.1"
+        onChange={handleChange}
+        error={addressError}
+      />
+
+      {/* Read-only tag field (tag mode) */}
+      <InputGroup
+        label="TID"
+        id="tid-a"
+        isTag={true}
+        value="E2003412012345678901234A"
+        placeholder="Leggi TAG A"
+      />
+    </div>
+  );
+}
+```
+
+## Note
+
+- In modalità tag (`isTag={true}`), il componente `Input` sottostante riceve `disabled={true}`, quindi `onChange` non viene mai chiamato anche se fornito.
+- La prop `error` influenza solo lo stile visivo e il testo del messaggio — la logica di validazione deve essere implementata dal componente padre.
+- `InputGroup` compone internamente i componenti `Input` e `InputLabel` della libreria. Le loro variabili CSS individuali (sfondo, colore testo, border radius, padding) si applicano anche qui.

--- a/docs/it/components/SpotRfidHeader.md
+++ b/docs/it/components/SpotRfidHeader.md
@@ -1,0 +1,76 @@
+# SpotRfidHeader
+
+> [English](../../../docs/components/SpotRfidHeader.md) | [Versión española](../../es/components/SpotRfidHeader.md)
+
+> ⚠️ **Esportato come `Header`** da `thecore-auth`. Importare con: `import { Header } from 'thecore-auth'`
+
+## Panoramica
+
+`SpotRfidHeader` è la barra di navigazione superiore per le applicazioni SPOT RFID. Mostra un'area logo, il titolo della pagina corrente e un pulsante contestuale — logout (sulla route home quando il login automatico è disabilitato) o navigazione indietro (sulle route non-home quando `showHeaderButton` è attivo).
+
+L'header si nasconde automaticamente durante il caricamento globale. Logo, titolo e visibilità del pulsante sono gestiti dai context interni della libreria.
+
+## Import
+
+```jsx
+import { Header } from 'thecore-auth';
+```
+
+## Props
+
+| Nome | Tipo | Default | Obbligatorio | Descrizione |
+|---|---|---|---|---|
+| `Logo` | `React component` | `undefined` | — | Componente SVG (funzione) renderizzato come logo dell'header. Ha priorità su `logo`. |
+| `logo` | `string` | `undefined` | — | URL di un'immagine da renderizzare come logo. Usato quando `Logo` non è fornito. Se nessuno dei due è presente, viene usato il logo MyTrack predefinito. |
+
+## Variabili CSS
+
+| Variabile | Default | Descrizione |
+|---|---|---|
+| `--header-height` | `60px` | Altezza della barra header |
+| `--width-logo-size` | `48px` | Larghezza del logo nell'header |
+
+## Utilizzo
+
+```jsx
+import { Header } from 'thecore-auth';
+import CompanyLogo from './assets/company-logo.svg?react';
+
+// Option 1: SVG component (recommended — avoids extra HTTP request)
+function App() {
+  return (
+    <div>
+      <Header Logo={CompanyLogo} />
+      <main>{/* contenuto pagina */}</main>
+    </div>
+  );
+}
+
+// Option 2: image URL
+function App() {
+  return (
+    <div>
+      <Header logo="/assets/company-logo.png" />
+      <main>{/* contenuto pagina */}</main>
+    </div>
+  );
+}
+
+// Option 3: default logo (no props needed)
+function App() {
+  return (
+    <div>
+      <Header />
+      <main>{/* contenuto pagina */}</main>
+    </div>
+  );
+}
+```
+
+## Note
+
+- Il pulsante logout appare solo quando `autoLogin` è `false` (da `useConfig`) **e** la route corrente corrisponde a `home/:id`.
+- Il pulsante indietro appare solo quando la route corrente **non** corrisponde a `home/:id` e `showHeaderButton` è `true` (da `useConfig`).
+- Il pulsante indietro chiama `navigate(-1)` di React Router — dipende dalla disponibilità della cronologia del browser.
+- Il titolo centrale proviene da `configRoutes` (via `useConfig`); se nessuna route corrisponde, viene usato `firstPrivateTitle`.
+- Richiede `AuthProvider`, `AlertProvider`, `ConfigProvider` e `LoadingProvider` nell'albero dei componenti.


### PR DESCRIPTION
## Summary
- 6 SPOT RFID component reference files in EN + IT + ES (18 files total)
- Covers: SpotRfidHeader (exported as Header), InputGroup, CardInputTag, CardInputRange, ConfigFileReader, ConfigFileReaderAllBrowser
- Schema: Overview · Import · Props · CSS Variables · Usage · Notes

Closes #14