### PR TITLE
docs(utils): add dateUtils and fetchAxiosConfig reference docs

### DIFF
--- a/docs/es/utils/dateUtils.md
+++ b/docs/es/utils/dateUtils.md
@@ -1,0 +1,151 @@
+# dateUtils
+
+> [English](../../utils/dateUtils.md) | [Versione italiana](../../it/utils/dateUtils.md)
+
+## Descripción general
+
+`dateUtils` es una colección de funciones puras para dar formato, manipular y convertir objetos `Date`. Todas las funciones son no-mutantes: siempre devuelven un nuevo valor y dejan el `Date` original sin modificar.
+
+## Importación
+
+```js
+import {
+  toDatetimeLocalValue,
+  setTime,
+  subtractDays,
+  parseUtcToLocal,
+  toDateValue,
+} from 'thecore-auth';
+```
+
+## Funciones
+
+### `toDatetimeLocalValue(date)`
+
+Convierte un objeto `Date` en una cadena compatible con `<input type="datetime-local">`.
+
+| Nombre | Tipo | Descripción |
+|--------|------|-------------|
+| `date` | `Date` | La fecha a convertir. |
+
+**Devuelve:** `string` — con el formato `"YYYY-MM-DDTHH:mm"`. Devuelve `''` si `date` no es una instancia de `Date`.
+
+```js
+const dt = new Date(2025, 5, 23, 14, 30); // 23 jun 2025, 14:30
+toDatetimeLocalValue(dt); // "2025-06-23T14:30"
+```
+
+---
+
+### `setTime(date, hours, minutes, seconds)`
+
+Devuelve un nuevo `Date` con los componentes de hora especificados aplicados a la fecha dada.
+
+| Nombre | Tipo | Descripción |
+|--------|------|-------------|
+| `date` | `Date` | La fecha base. |
+| `hours` | `number` | Horas a establecer (0–23). |
+| `minutes` | `number` | Minutos a establecer (0–59). Por defecto `0`. |
+| `seconds` | `number` | Segundos a establecer (0–59). Por defecto `0`. |
+
+**Devuelve:** `Date` — nueva fecha con la hora especificada. Devuelve `null` si `date` no es una instancia de `Date`.
+
+```js
+const base = new Date(2025, 5, 23);
+setTime(base, 9, 30); // 2025-06-23 09:30:00
+setTime(base, 17, 0, 0); // 2025-06-23 17:00:00
+```
+
+---
+
+### `subtractDays(date, days)`
+
+Devuelve un nuevo `Date` que precede en `days` días a la fecha dada.
+
+| Nombre | Tipo | Descripción |
+|--------|------|-------------|
+| `date` | `Date` | La fecha de inicio. |
+| `days` | `number` | Número de días a restar. |
+
+**Devuelve:** `Date` — nueva fecha desplazada `days` días hacia atrás. Devuelve `null` si `date` no es una instancia de `Date`.
+
+```js
+const today = new Date(2025, 5, 23);
+subtractDays(today, 7); // 2025-06-16
+subtractDays(today, 1); // 2025-06-22
+```
+
+---
+
+### `parseUtcToLocal(utcString)`
+
+Analiza una cadena de fecha UTC y la convierte en un objeto `Date` en el huso horario local del navegador.
+
+| Nombre | Tipo | Descripción |
+|--------|------|-------------|
+| `utcString` | `string` | Una cadena de fecha UTC (p. ej. `"2025-06-23T12:00:00Z"`). |
+
+**Devuelve:** `Date` — el `Date` equivalente en hora local.
+
+```js
+// En una zona UTC+2:
+parseUtcToLocal('2025-06-23T10:00:00Z'); // 2025-06-23T12:00:00 local
+```
+
+---
+
+### `toDateValue(date)`
+
+Convierte un objeto `Date` en una cadena compatible con `<input type="date">` usando los componentes UTC.
+
+| Nombre | Tipo | Descripción |
+|--------|------|-------------|
+| `date` | `Date` | La fecha a convertir. |
+
+**Devuelve:** `string` — con el formato `"YYYY-MM-DD"`. Devuelve `''` si `date` no es una instancia de `Date`.
+
+```js
+const d = new Date('2025-06-23T00:00:00Z');
+toDateValue(d); // "2025-06-23"
+```
+
+---
+
+## Uso
+
+```jsx
+import { toDatetimeLocalValue, setTime, subtractDays, parseUtcToLocal, toDateValue } from 'thecore-auth';
+
+function ShiftScheduler({ shiftDate }) {
+  // Restringe las reservas a los últimos 30 días
+  const earliest = subtractDays(new Date(), 30);
+
+  // Construye el valor datetime-local para el inicio del turno a las 08:00
+  const shiftStart = setTime(shiftDate, 8, 0, 0);
+  const shiftStartValue = toDatetimeLocalValue(shiftStart);
+
+  // Construye el valor datetime-local para el fin a las 17:00
+  const shiftEnd = setTime(shiftDate, 17, 0, 0);
+  const shiftEndValue = toDatetimeLocalValue(shiftEnd);
+
+  // Muestra la fecha del turno desde una cadena UTC recibida de la API
+  const localShiftDate = parseUtcToLocal(shiftDate.toISOString());
+  const dateInputValue = toDateValue(localShiftDate);
+
+  return (
+    <form>
+      <input type="date" value={dateInputValue} min={toDateValue(earliest)} readOnly />
+      <input type="datetime-local" value={shiftStartValue} readOnly />
+      <input type="datetime-local" value={shiftEndValue} readOnly />
+    </form>
+  );
+}
+```
+
+## Notas
+
+- Todas las funciones son **puras**: nunca mutan el `Date` de entrada.
+- `toDatetimeLocalValue` usa los componentes de la **hora local** (`getHours`, `getDate`, …), por lo que el resultado refleja el huso horario del usuario.
+- `toDateValue` usa los **componentes UTC** (`getUTCFullYear`, `getUTCMonth`, `getUTCDate`), coherente con cómo `<input type="date">` gestiona los valores.
+- `parseUtcToLocal` aplica manualmente `getTimezoneOffset()` para desplazar la hora. Es útil cuando el servidor devuelve un timestamp UTC que debe mostrarse en hora local sin depender de la conversión automática de JS.
+- `setTime` pone a cero los milisegundos además de establecer las horas, minutos y segundos especificados.

--- a/docs/es/utils/fetchAxiosConfig.md
+++ b/docs/es/utils/fetchAxiosConfig.md
@@ -1,0 +1,118 @@
+# fetchAxiosConfig
+
+> [English](../../utils/fetchAxiosConfig.md) | [Versione italiana](../../it/utils/fetchAxiosConfig.md)
+
+## Descripción general
+
+`fetchAxiosConfig` es una factory asíncrona que crea y almacena en caché una instancia [Axios](https://axios-http.com/) preconfigurada. Lee `baseURL` y los mensajes de error desde `/config.json`, inyecta automáticamente el token JWT de acceso desde `localStorage` en cada petición y gestiona los errores HTTP `401`, `404` y genéricos a través de un único response interceptor.
+
+La instancia es un singleton: llamar a `fetchAxiosConfig` varias veces siempre devuelve la misma instancia Axios sin volver a leer la configuración ni registrar los interceptores de nuevo.
+
+## Importación
+
+```js
+import { fetchAxiosConfig } from 'thecore-auth';
+```
+
+## Funciones
+
+### `fetchAxiosConfig(alert, onUnauthorized, onNotFound, onGenericError)`
+
+Crea (o devuelve de la caché) la instancia Axios configurada para la aplicación actual.
+
+| Nombre | Tipo | Descripción |
+|--------|------|-------------|
+| `alert` | `(type: string, message: string) => void` \| `undefined` | Callback invocado para mostrar una notificación de error. `type` es siempre `'danger'`. Típicamente la función `alert` de `useAlert`. |
+| `onUnauthorized` | `() => void` \| `undefined` | Llamado cuando se recibe una respuesta `401`. Úsalo para redirigir al usuario a la página de login. |
+| `onNotFound` | `(error: AxiosError) => void` \| `undefined` | Llamado cuando se recibe una respuesta `404`. |
+| `onGenericError` | `(error: AxiosError) => void` \| `undefined` | Llamado para cualquier otro estado de error HTTP. |
+
+**Devuelve:** `Promise<AxiosInstance>` — la instancia Axios singleton configurada.
+
+**Estructura del archivo de config** (`/config.json`):
+
+```json
+{
+  "baseUri": "https://api.example.com",
+  "axiosErrors": {
+    "unauthorized": "Sesión expirada. Inicia sesión de nuevo.",
+    "notFound": "El recurso solicitado no fue encontrado.",
+    "defaultMessage": "Se produjo un error."
+  }
+}
+```
+
+**Comportamiento del request interceptor:**
+- Lee `accessToken` desde `localStorage` (almacenado como cadena JSON).
+- Si existe el token, establece `Authorization: Bearer <token>` en la petición.
+- Si no existe ningún token y no hay ya un header `Authorization`, lo elimina por completo.
+
+**Comportamiento del response interceptor:**
+
+| Estado | Acción |
+|--------|--------|
+| `401` | Elimina `accessToken` de `localStorage`, llama a `alert('danger', unauthorized)`, llama a `onUnauthorized()` |
+| `404` | Llama a `alert('danger', notFound)`, llama a `onNotFound(error)` |
+| Otros errores | Llama a `alert('danger', defaultMessage + status + data.error)`, llama a `onGenericError(error)` |
+
+Todos los casos de error rechazan de nuevo la promise, de modo que el `.catch()` / `try-catch` del llamante sigue ejecutándose.
+
+```js
+const axios = await fetchAxiosConfig(
+  (type, msg) => showToast(type, msg),
+  () => navigate('/login'),
+  (err) => console.warn('Not found', err),
+  (err) => console.error('Server error', err),
+);
+
+const { data } = await axios.get('/users/me');
+```
+
+---
+
+## Uso
+
+```jsx
+import { fetchAxiosConfig, useAlert, useAuth } from 'thecore-auth';
+import { useNavigate } from 'react-router-dom';
+import { useEffect, useState } from 'react';
+
+function UserProfile() {
+  const { alert } = useAlert();
+  const navigate = useNavigate();
+  const [profile, setProfile] = useState(null);
+
+  useEffect(() => {
+    const loadProfile = async () => {
+      const axios = await fetchAxiosConfig(
+        alert,
+        () => navigate('/login'),   // redirige al login en 401
+        (err) => console.warn('Not found:', err.response?.config?.url),
+        (err) => console.error('Error inesperado:', err),
+      );
+
+      const { data } = await axios.get('/users/me');
+      setProfile(data);
+    };
+
+    loadProfile();
+  }, []);
+
+  if (!profile) return <p>Cargando...</p>;
+
+  return (
+    <div>
+      <h1>{profile.name}</h1>
+      <p>{profile.email}</p>
+    </div>
+  );
+}
+```
+
+## Notas
+
+- **Patrón singleton**: la instancia se crea una sola vez por carga de página. Si necesitas distintos `baseURL` o interceptores para diferentes servicios, ten en cuenta que la implementación actual usa una única variable a nivel de módulo: todos los llamantes comparten la misma instancia.
+- **Fuente del token**: el token se lee desde `localStorage` en cada petición (dentro del request interceptor), por lo que los refresh del token se reflejan automáticamente sin recrear la instancia.
+- **Errores de configuración**: si `/config.json` no puede obtenerse o analizarse, la factory registra el error en consola y devuelve `undefined`. En los llamantes, verifica el valor devuelto antes de usarlo.
+- **Todos los parámetros callback son opcionales**: pasa `undefined` para los manejadores que no necesites. El interceptor usa optional chaining (`?.`) para todas las callbacks.
+- La factory depende de `/config.json` servido en la raíz del servidor dev/prod. En los tests, mockea `fetch` o proporciona un archivo de config local.

--- a/docs/it/utils/dateUtils.md
+++ b/docs/it/utils/dateUtils.md
@@ -1,0 +1,151 @@
+# dateUtils
+
+> [English](../../utils/dateUtils.md) | [Versión española](../../es/utils/dateUtils.md)
+
+## Panoramica
+
+`dateUtils` è una raccolta di funzioni pure per la formattazione, la manipolazione e la conversione di oggetti `Date`. Tutte le funzioni sono non-mutanti: restituiscono sempre un nuovo valore e lasciano la `Date` originale invariata.
+
+## Import
+
+```js
+import {
+  toDatetimeLocalValue,
+  setTime,
+  subtractDays,
+  parseUtcToLocal,
+  toDateValue,
+} from 'thecore-auth';
+```
+
+## Funzioni
+
+### `toDatetimeLocalValue(date)`
+
+Converte un oggetto `Date` in una stringa compatibile con `<input type="datetime-local">`.
+
+| Nome | Tipo | Descrizione |
+|------|------|-------------|
+| `date` | `Date` | La data da convertire. |
+
+**Restituisce:** `string` — nel formato `"YYYY-MM-DDTHH:mm"`. Restituisce `''` se `date` non è un'istanza di `Date`.
+
+```js
+const dt = new Date(2025, 5, 23, 14, 30); // 23 giu 2025, 14:30
+toDatetimeLocalValue(dt); // "2025-06-23T14:30"
+```
+
+---
+
+### `setTime(date, hours, minutes, seconds)`
+
+Restituisce una nuova `Date` con le componenti orarie specificate applicate alla data fornita.
+
+| Nome | Tipo | Descrizione |
+|------|------|-------------|
+| `date` | `Date` | La data base. |
+| `hours` | `number` | Ore da impostare (0–23). |
+| `minutes` | `number` | Minuti da impostare (0–59). Default `0`. |
+| `seconds` | `number` | Secondi da impostare (0–59). Default `0`. |
+
+**Restituisce:** `Date` — nuova data con l'orario specificato. Restituisce `null` se `date` non è un'istanza di `Date`.
+
+```js
+const base = new Date(2025, 5, 23);
+setTime(base, 9, 30); // 2025-06-23 09:30:00
+setTime(base, 17, 0, 0); // 2025-06-23 17:00:00
+```
+
+---
+
+### `subtractDays(date, days)`
+
+Restituisce una nuova `Date` che precede di `days` giorni la data fornita.
+
+| Nome | Tipo | Descrizione |
+|------|------|-------------|
+| `date` | `Date` | La data di partenza. |
+| `days` | `number` | Numero di giorni da sottrarre. |
+
+**Restituisce:** `Date` — nuova data spostata indietro di `days` giorni. Restituisce `null` se `date` non è un'istanza di `Date`.
+
+```js
+const today = new Date(2025, 5, 23);
+subtractDays(today, 7); // 2025-06-16
+subtractDays(today, 1); // 2025-06-22
+```
+
+---
+
+### `parseUtcToLocal(utcString)`
+
+Analizza una stringa di data UTC e la converte in un oggetto `Date` nel fuso orario locale del browser.
+
+| Nome | Tipo | Descrizione |
+|------|------|-------------|
+| `utcString` | `string` | Una stringa di data UTC (es. `"2025-06-23T12:00:00Z"`). |
+
+**Restituisce:** `Date` — la `Date` equivalente nell'ora locale.
+
+```js
+// In un fuso UTC+2:
+parseUtcToLocal('2025-06-23T10:00:00Z'); // 2025-06-23T12:00:00 locale
+```
+
+---
+
+### `toDateValue(date)`
+
+Converte un oggetto `Date` in una stringa compatibile con `<input type="date">` usando le componenti UTC.
+
+| Nome | Tipo | Descrizione |
+|------|------|-------------|
+| `date` | `Date` | La data da convertire. |
+
+**Restituisce:** `string` — nel formato `"YYYY-MM-DD"`. Restituisce `''` se `date` non è un'istanza di `Date`.
+
+```js
+const d = new Date('2025-06-23T00:00:00Z');
+toDateValue(d); // "2025-06-23"
+```
+
+---
+
+## Utilizzo
+
+```jsx
+import { toDatetimeLocalValue, setTime, subtractDays, parseUtcToLocal, toDateValue } from 'thecore-auth';
+
+function ShiftScheduler({ shiftDate }) {
+  // Limita le prenotazioni agli ultimi 30 giorni
+  const earliest = subtractDays(new Date(), 30);
+
+  // Costruisce il valore datetime-local per l'inizio del turno alle 08:00
+  const shiftStart = setTime(shiftDate, 8, 0, 0);
+  const shiftStartValue = toDatetimeLocalValue(shiftStart);
+
+  // Costruisce il valore datetime-local per la fine alle 17:00
+  const shiftEnd = setTime(shiftDate, 17, 0, 0);
+  const shiftEndValue = toDatetimeLocalValue(shiftEnd);
+
+  // Mostra la data del turno da una stringa UTC ricevuta dall'API
+  const localShiftDate = parseUtcToLocal(shiftDate.toISOString());
+  const dateInputValue = toDateValue(localShiftDate);
+
+  return (
+    <form>
+      <input type="date" value={dateInputValue} min={toDateValue(earliest)} readOnly />
+      <input type="datetime-local" value={shiftStartValue} readOnly />
+      <input type="datetime-local" value={shiftEndValue} readOnly />
+    </form>
+  );
+}
+```
+
+## Note
+
+- Tutte le funzioni sono **pure**: non modificano mai la `Date` di input.
+- `toDatetimeLocalValue` usa le componenti dell'**ora locale** (`getHours`, `getDate`, …), quindi il risultato riflette il fuso orario dell'utente.
+- `toDateValue` usa le **componenti UTC** (`getUTCFullYear`, `getUTCMonth`, `getUTCDate`), coerente con il modo in cui `<input type="date">` gestisce i valori.
+- `parseUtcToLocal` applica manualmente `getTimezoneOffset()` per traslare il tempo. È utile quando il server restituisce un timestamp UTC che deve essere mostrato nell'ora locale senza affidarsi alla conversione automatica di JS.
+- `setTime` azzera i millisecondi oltre a impostare ore, minuti e secondi specificati.

--- a/docs/it/utils/fetchAxiosConfig.md
+++ b/docs/it/utils/fetchAxiosConfig.md
@@ -1,0 +1,118 @@
+# fetchAxiosConfig
+
+> [English](../../utils/fetchAxiosConfig.md) | [Versión española](../../es/utils/fetchAxiosConfig.md)
+
+## Panoramica
+
+`fetchAxiosConfig` è una factory asincrona che crea e memorizza nella cache un'istanza [Axios](https://axios-http.com/) preconfigurata. Legge `baseURL` e i messaggi di errore da `/config.json`, inietta automaticamente il token JWT di accesso da `localStorage` in ogni richiesta e gestisce gli errori HTTP `401`, `404` e generici tramite un unico response interceptor.
+
+L'istanza è un singleton: chiamare `fetchAxiosConfig` più volte restituisce sempre la stessa istanza Axios senza rileggere la configurazione né registrare nuovamente gli interceptor.
+
+## Import
+
+```js
+import { fetchAxiosConfig } from 'thecore-auth';
+```
+
+## Funzioni
+
+### `fetchAxiosConfig(alert, onUnauthorized, onNotFound, onGenericError)`
+
+Crea (o restituisce dalla cache) l'istanza Axios configurata per l'applicazione corrente.
+
+| Nome | Tipo | Descrizione |
+|------|------|-------------|
+| `alert` | `(type: string, message: string) => void` \| `undefined` | Callback invocato per mostrare una notifica di errore. `type` è sempre `'danger'`. Tipicamente la funzione `alert` di `useAlert`. |
+| `onUnauthorized` | `() => void` \| `undefined` | Chiamato quando si riceve una risposta `401`. Usalo per reindirizzare l'utente alla pagina di login. |
+| `onNotFound` | `(error: AxiosError) => void` \| `undefined` | Chiamato quando si riceve una risposta `404`. |
+| `onGenericError` | `(error: AxiosError) => void` \| `undefined` | Chiamato per qualsiasi altro stato di errore HTTP. |
+
+**Restituisce:** `Promise<AxiosInstance>` — l'istanza Axios singleton configurata.
+
+**Struttura del file di config** (`/config.json`):
+
+```json
+{
+  "baseUri": "https://api.example.com",
+  "axiosErrors": {
+    "unauthorized": "Sessione scaduta. Effettua nuovamente il login.",
+    "notFound": "La risorsa richiesta non è stata trovata.",
+    "defaultMessage": "Si è verificato un errore."
+  }
+}
+```
+
+**Comportamento del request interceptor:**
+- Legge `accessToken` da `localStorage` (memorizzato come stringa JSON).
+- Se il token esiste, imposta `Authorization: Bearer <token>` sulla richiesta.
+- Se non esiste alcun token e non è già presente un header `Authorization`, lo rimuove completamente.
+
+**Comportamento del response interceptor:**
+
+| Stato | Azione |
+|-------|--------|
+| `401` | Rimuove `accessToken` da `localStorage`, chiama `alert('danger', unauthorized)`, chiama `onUnauthorized()` |
+| `404` | Chiama `alert('danger', notFound)`, chiama `onNotFound(error)` |
+| Altri errori | Chiama `alert('danger', defaultMessage + status + data.error)`, chiama `onGenericError(error)` |
+
+Tutti i casi di errore rigettano nuovamente la promise, così il `.catch()` / `try-catch` del chiamante viene comunque eseguito.
+
+```js
+const axios = await fetchAxiosConfig(
+  (type, msg) => showToast(type, msg),
+  () => navigate('/login'),
+  (err) => console.warn('Not found', err),
+  (err) => console.error('Server error', err),
+);
+
+const { data } = await axios.get('/users/me');
+```
+
+---
+
+## Utilizzo
+
+```jsx
+import { fetchAxiosConfig, useAlert, useAuth } from 'thecore-auth';
+import { useNavigate } from 'react-router-dom';
+import { useEffect, useState } from 'react';
+
+function UserProfile() {
+  const { alert } = useAlert();
+  const navigate = useNavigate();
+  const [profile, setProfile] = useState(null);
+
+  useEffect(() => {
+    const loadProfile = async () => {
+      const axios = await fetchAxiosConfig(
+        alert,
+        () => navigate('/login'),   // redirect al login su 401
+        (err) => console.warn('Not found:', err.response?.config?.url),
+        (err) => console.error('Errore inatteso:', err),
+      );
+
+      const { data } = await axios.get('/users/me');
+      setProfile(data);
+    };
+
+    loadProfile();
+  }, []);
+
+  if (!profile) return <p>Caricamento...</p>;
+
+  return (
+    <div>
+      <h1>{profile.name}</h1>
+      <p>{profile.email}</p>
+    </div>
+  );
+}
+```
+
+## Note
+
+- **Pattern singleton**: l'istanza viene creata una sola volta per caricamento della pagina. Se hai bisogno di `baseURL` o interceptor diversi per servizi differenti, tieni presente che l'implementazione attuale usa una singola variabile a livello di modulo: tutti i chiamanti condividono la stessa istanza.
+- **Sorgente del token**: il token viene letto da `localStorage` ad ogni richiesta (dentro il request interceptor), quindi i refresh del token si riflettono automaticamente senza ricreare l'istanza.
+- **Errori di configurazione**: se `/config.json` non può essere recuperato o analizzato, la factory registra l'errore in console e restituisce `undefined`. Nei chiamanti, verifica il valore restituito prima di usarlo.
+- **Tutti i parametri callback sono opzionali**: passa `undefined` per i gestori non necessari. L'interceptor usa l'optional chaining (`?.`) per tutte le callback.
+- La factory dipende da `/config.json` servito alla radice del server dev/prod. Nei test, mocka `fetch` o fornisci un file di config locale.

--- a/docs/utils/dateUtils.md
+++ b/docs/utils/dateUtils.md
@@ -1,0 +1,151 @@
+# dateUtils
+
+> [Versione italiana](../../it/utils/dateUtils.md) | [Versión española](../../es/utils/dateUtils.md)
+
+## Overview
+
+`dateUtils` is a collection of pure date utility functions for formatting, manipulating, and converting `Date` objects. All functions are non-mutating: they always return a new value and leave the original `Date` unchanged.
+
+## Import
+
+```js
+import {
+  toDatetimeLocalValue,
+  setTime,
+  subtractDays,
+  parseUtcToLocal,
+  toDateValue,
+} from 'thecore-auth';
+```
+
+## Functions
+
+### `toDatetimeLocalValue(date)`
+
+Converts a `Date` object to a string compatible with `<input type="datetime-local">`.
+
+| Name | Type | Description |
+|------|------|-------------|
+| `date` | `Date` | The date to convert. |
+
+**Returns:** `string` — formatted as `"YYYY-MM-DDTHH:mm"`. Returns `''` if `date` is not a `Date` instance.
+
+```js
+const dt = new Date(2025, 5, 23, 14, 30); // 23 Jun 2025, 14:30
+toDatetimeLocalValue(dt); // "2025-06-23T14:30"
+```
+
+---
+
+### `setTime(date, hours, minutes, seconds)`
+
+Returns a new `Date` with the specified time components applied to the given date.
+
+| Name | Type | Description |
+|------|------|-------------|
+| `date` | `Date` | The base date. |
+| `hours` | `number` | Hours to set (0–23). |
+| `minutes` | `number` | Minutes to set (0–59). Defaults to `0`. |
+| `seconds` | `number` | Seconds to set (0–59). Defaults to `0`. |
+
+**Returns:** `Date` — new date with the given time. Returns `null` if `date` is not a `Date` instance.
+
+```js
+const base = new Date(2025, 5, 23);
+setTime(base, 9, 30); // 2025-06-23 09:30:00
+setTime(base, 17, 0, 0); // 2025-06-23 17:00:00
+```
+
+---
+
+### `subtractDays(date, days)`
+
+Returns a new `Date` that is `days` days before the given date.
+
+| Name | Type | Description |
+|------|------|-------------|
+| `date` | `Date` | The starting date. |
+| `days` | `number` | Number of days to subtract. |
+
+**Returns:** `Date` — new date shifted back by `days` days. Returns `null` if `date` is not a `Date` instance.
+
+```js
+const today = new Date(2025, 5, 23);
+subtractDays(today, 7); // 2025-06-16
+subtractDays(today, 1); // 2025-06-22
+```
+
+---
+
+### `parseUtcToLocal(utcString)`
+
+Parses a UTC date string and converts it to a `Date` object in the browser's local timezone.
+
+| Name | Type | Description |
+|------|------|-------------|
+| `utcString` | `string` | A UTC date string (e.g. `"2025-06-23T12:00:00Z"`). |
+
+**Returns:** `Date` — the equivalent local-time `Date`.
+
+```js
+// In a UTC+2 timezone:
+parseUtcToLocal('2025-06-23T10:00:00Z'); // 2025-06-23T12:00:00 local
+```
+
+---
+
+### `toDateValue(date)`
+
+Converts a `Date` object to a string compatible with `<input type="date">` using UTC components.
+
+| Name | Type | Description |
+|------|------|-------------|
+| `date` | `Date` | The date to convert. |
+
+**Returns:** `string` — formatted as `"YYYY-MM-DD"`. Returns `''` if `date` is not a `Date` instance.
+
+```js
+const d = new Date('2025-06-23T00:00:00Z');
+toDateValue(d); // "2025-06-23"
+```
+
+---
+
+## Usage
+
+```jsx
+import { toDatetimeLocalValue, setTime, subtractDays, parseUtcToLocal, toDateValue } from 'thecore-auth';
+
+function ShiftScheduler({ shiftDate }) {
+  // Restrict bookings to the past 30 days
+  const earliest = subtractDays(new Date(), 30);
+
+  // Build a datetime-local value for the start of the shift day at 08:00
+  const shiftStart = setTime(shiftDate, 8, 0, 0);
+  const shiftStartValue = toDatetimeLocalValue(shiftStart);
+
+  // Build a datetime-local value for the end at 17:00
+  const shiftEnd = setTime(shiftDate, 17, 0, 0);
+  const shiftEndValue = toDatetimeLocalValue(shiftEnd);
+
+  // Display the shift date from a UTC string coming from the API
+  const localShiftDate = parseUtcToLocal(shiftDate.toISOString());
+  const dateInputValue = toDateValue(localShiftDate);
+
+  return (
+    <form>
+      <input type="date" value={dateInputValue} min={toDateValue(earliest)} readOnly />
+      <input type="datetime-local" value={shiftStartValue} readOnly />
+      <input type="datetime-local" value={shiftEndValue} readOnly />
+    </form>
+  );
+}
+```
+
+## Notes
+
+- All functions are **pure**: they never mutate the input `Date`.
+- `toDatetimeLocalValue` uses **local time** components (`getHours`, `getDate`, …), so the output reflects the user's timezone.
+- `toDateValue` uses **UTC components** (`getUTCFullYear`, `getUTCMonth`, `getUTCDate`), which is consistent with how `<input type="date">` handles values.
+- `parseUtcToLocal` manually applies `getTimezoneOffset()` to shift the time. This is useful when a server returns a UTC timestamp that needs to be displayed as local time without relying on automatic JS timezone conversion.
+- `setTime` resets milliseconds to `0` in addition to the specified hours, minutes, and seconds.

--- a/docs/utils/fetchAxiosConfig.md
+++ b/docs/utils/fetchAxiosConfig.md
@@ -1,0 +1,118 @@
+# fetchAxiosConfig
+
+> [Versione italiana](../../it/utils/fetchAxiosConfig.md) | [Versión española](../../es/utils/fetchAxiosConfig.md)
+
+## Overview
+
+`fetchAxiosConfig` is an async factory that creates and caches a pre-configured [Axios](https://axios-http.com/) instance. It reads `baseURL` and error messages from `/config.json`, automatically injects the JWT access token from `localStorage` into every request, and handles `401`, `404`, and generic HTTP errors through a unified response interceptor.
+
+The instance is a singleton: calling `fetchAxiosConfig` multiple times always returns the same Axios instance without re-reading the config or re-registering interceptors.
+
+## Import
+
+```js
+import { fetchAxiosConfig } from 'thecore-auth';
+```
+
+## Functions
+
+### `fetchAxiosConfig(alert, onUnauthorized, onNotFound, onGenericError)`
+
+Creates (or returns the cached) Axios instance configured for the current application.
+
+| Name | Type | Description |
+|------|------|-------------|
+| `alert` | `(type: string, message: string) => void` \| `undefined` | Callback invoked to display an error notification. `type` is always `'danger'`. Typically the `alert` function from `useAlert`. |
+| `onUnauthorized` | `() => void` \| `undefined` | Called when a `401` response is received. Use this to redirect the user to the login page. |
+| `onNotFound` | `(error: AxiosError) => void` \| `undefined` | Called when a `404` response is received. |
+| `onGenericError` | `(error: AxiosError) => void` \| `undefined` | Called for any other HTTP error status. |
+
+**Returns:** `Promise<AxiosInstance>` — the configured singleton Axios instance.
+
+**Config file shape** (`/config.json`):
+
+```json
+{
+  "baseUri": "https://api.example.com",
+  "axiosErrors": {
+    "unauthorized": "Session expired. Please log in again.",
+    "notFound": "The requested resource was not found.",
+    "defaultMessage": "An error occurred."
+  }
+}
+```
+
+**Request interceptor behavior:**
+- Reads `accessToken` from `localStorage` (stored as a JSON-encoded string).
+- If a token exists, sets `Authorization: Bearer <token>` on the request.
+- If no token exists and no `Authorization` header was already set, removes the header entirely.
+
+**Response interceptor behavior:**
+
+| Status | Action |
+|--------|--------|
+| `401` | Removes `accessToken` from `localStorage`, calls `alert('danger', unauthorized)`, calls `onUnauthorized()` |
+| `404` | Calls `alert('danger', notFound)`, calls `onNotFound(error)` |
+| Other errors | Calls `alert('danger', defaultMessage + status + data.error)`, calls `onGenericError(error)` |
+
+All error cases re-reject the promise so the caller's `.catch()` / `try-catch` still runs.
+
+```js
+const axios = await fetchAxiosConfig(
+  (type, msg) => showToast(type, msg),
+  () => navigate('/login'),
+  (err) => console.warn('Not found', err),
+  (err) => console.error('Server error', err),
+);
+
+const { data } = await axios.get('/users/me');
+```
+
+---
+
+## Usage
+
+```jsx
+import { fetchAxiosConfig, useAlert, useAuth } from 'thecore-auth';
+import { useNavigate } from 'react-router-dom';
+import { useEffect, useState } from 'react';
+
+function UserProfile() {
+  const { alert } = useAlert();
+  const navigate = useNavigate();
+  const [profile, setProfile] = useState(null);
+
+  useEffect(() => {
+    const loadProfile = async () => {
+      const axios = await fetchAxiosConfig(
+        alert,
+        () => navigate('/login'),   // redirect on 401
+        (err) => console.warn('Not found:', err.response?.config?.url),
+        (err) => console.error('Unexpected error:', err),
+      );
+
+      const { data } = await axios.get('/users/me');
+      setProfile(data);
+    };
+
+    loadProfile();
+  }, []);
+
+  if (!profile) return <p>Loading...</p>;
+
+  return (
+    <div>
+      <h1>{profile.name}</h1>
+      <p>{profile.email}</p>
+    </div>
+  );
+}
+```
+
+## Notes
+
+- **Singleton pattern**: the instance is created only once per page load. If you need different base URLs or interceptors for different services, call `fetchAxiosConfig` in separate modules — but note the current implementation uses a single module-level variable, so all callers share the same instance.
+- **Token source**: the token is read from `localStorage` on every request (inside the request interceptor), so token refreshes are reflected automatically without re-creating the instance.
+- **Config errors**: if `/config.json` cannot be fetched or parsed, the factory logs the error to the console and returns `undefined`. Guard against this in callers by checking the return value before use.
+- **All callback parameters are optional**: pass `undefined` for any handler you do not need. The interceptor uses optional chaining (`?.`) for all callbacks.
+- The factory depends on `/config.json` being served at the root of the dev/prod server. In tests, mock `fetch` or provide a local config file accordingly.


### PR DESCRIPTION
## Summary
- 2 utility reference files in EN + IT + ES (6 files total)
- Covers: dateUtils (5 functions), fetchAxiosConfig (Axios factory)
- Schema: Overview · Import · Functions · Usage · Notes

Closes #16