### PR TITLE
docs(agents): rewrite AGENTS.md for thecore-auth, drop Bancolini planner content

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,10 +34,10 @@ Before doing anything else, classify the request into one of these types:
 | `code` | `src/`, dependencies, tests | ✅ Yes — Steps 1–5 |
 | `config` | `public/config.json`, `vite.config.js` | ✅ Yes — Steps 1–5 |
 | `docs` | `AGENTS.md`, `.claude/skills/`, `.claude/settings.json` hooks | ✅ Yes — Steps 1–5 |
-| `readme` | `README.md`, `CHANGELOG.md`, translations | Step 1 light + translation update |
+| `readme` | `README.md`, `CHANGELOG.md`, `DOCUMENTATION_IT.md`/`DOCUMENTATION_ES.md` | Step 1 light + translation update |
 
 **Why `config` and `docs` require the full workflow:**
-- `public/config.json` changes affect runtime behavior of the app.
+- `public/config.json` changes affect the dev/test runtime behavior of the demo app.
 - `AGENTS.md` changes affect every future AI session on this repo — a wrong rule propagates everywhere.
 - Skills and hooks change what the AI does automatically — same risk level as code.
 
@@ -53,13 +53,19 @@ STEP 2 ─ Can you settle everything in conversation?
           NO  → /prototype (throwaway session) → /handoff (bring the result back) → return to STEP 1
 
 STEP 3 ─ Is this a multi-session build? (> 1 issue, > 1 component, estimate > 2h)
-          YES → /to-prd   (PRD as an issue)
+          YES → /to-prd   (PRD as a GitHub Issue)
                 /to-issues (split into independent, vertically sliced issues)
                 Then: a NEW session per issue → /implement with PRD + single issue
           NO  → /implement in the same context window
 
 STEP 4 ─ Git workflow (see §2)
           Feature branch → atomic commits → PR toward main → stop, no autonomous merge
+
+STEP 4.5 ─ Changelog (see §2.9) — MANDATORY before every push
+            1. Create docs/en/changelog/YYYY-MM-DD-X.Y.Z-branch-name.md using the template in §2.9
+            2. Update CHANGELOG.md master index with a link + one-line summary
+            3. Create the Italian translation in docs/it/changelog/
+            Do not push before this step is complete.
 
 STEP 5 ─ /tdd
           Every implementation follows red-green-refactor.
@@ -79,7 +85,7 @@ Bug report / feature request received externally?
 ```
 Have a spare moment between tasks? Run:
 → /improve-codebase-architecture
-   Reads CONTEXT.md and docs/adr/ and identifies deepening opportunities.
+   Reads CONTEXT.md and docs/en/adr/ and identifies deepening opportunities.
    Each opportunity becomes an idea → re-enters the main flow at STEP 1.
 ```
 
@@ -180,7 +186,8 @@ BREAKING CHANGE: add as footer or with ! after the type
 
 ### 2.5 GitHub Issues — issue and task tracking (MANDATORY)
 
-This project uses **GitHub Issues** as the issue tracker.
+This project uses **GitHub Issues** as the issue tracker, alongside Asana (see §2.6) — both are
+mandatory, not alternatives.
 Repository: [https://github.com/SantiGalvan/thecore-auth](https://github.com/SantiGalvan/thecore-auth)
 
 **Every implementation must have a corresponding GitHub Issue.**
@@ -198,8 +205,9 @@ Repository: [https://github.com/SantiGalvan/thecore-auth](https://github.com/San
 3. When done: close the issue via the PR description (`Closes #123`).
 
 **Mandatory traceability rule:**
-Every change to the codebase — no matter how small — must have a corresponding GitHub Issue.
-Before ending a session, verify that all changes are tracked. Create any missing issues immediately.
+Every change to the codebase — no matter how small — must have a corresponding GitHub Issue
+**and** a corresponding Asana subtask (§2.6). Before ending a session, verify that all changes are
+tracked in both systems. Create any missing issue/subtask immediately.
 
 **GitHub CLI:**
 ```bash
@@ -213,7 +221,42 @@ gh issue list
 gh issue view 123
 ```
 
-### 2.6 PR rules
+### 2.6 Asana — sprint tracking (MANDATORY)
+
+Every GitHub Issue above also gets a matching Asana task, so the team's sprint board reflects work
+happening in this repo. Asana tasks are **in addition to** GitHub Issues, not a replacement.
+
+**Project: always "Sviluppo Sprint" — never "MyTask"** (that project belongs to the Bancolini
+planner app, a different codebase). Do not ask the user which project to use — it is fixed.
+
+**Resolving the project and current sprint (no hardcoded GIDs — look them up every time):**
+1. Call the workspace-listing tool to find the `bancolini.com` workspace GID.
+2. Call `asana_get_projects_for_workspace` on that workspace and find the project named
+   **"Sviluppo Sprint"** by name — never assume its GID is stable across sessions.
+3. Call `asana_get_project_sections` on that project's GID.
+4. Find the section named `Sprint DD Mmm–DD Mmm YYYY` whose date range includes today.
+   **Always use the current sprint.** Never use Backlog unless no active sprint section exists.
+
+**Structure for every implementation:**
+- **Main task** → one task per implementation, named in Italian as a plain description with no
+  Conventional Commits prefix (e.g. `Aggiunta traduzione spagnola alla documentazione`, not
+  `docs(readme): add spanish translation`).
+- **Subtasks** → one subtask per GitHub Issue in this implementation, referencing the issue number
+  (e.g. `Tradurre AGENTS.md in spagnolo (#42)`).
+
+**Rules for every task and subtask created:**
+- **Language**: task names and descriptions always in **Italian** (this is an internal
+  Bancolini-team tracking tool — independent from the [English-only rule](#4-language-rules-mandatory)
+  that governs the repo's own code and docs).
+- **Assignee**: always `"me"`.
+- **Section**: always the current sprint section (see above).
+
+**Lifecycle:**
+1. Before starting: create the main task + one subtask per GitHub Issue.
+2. During work: mark each subtask complete when its GitHub Issue is closed.
+3. When all subtasks are complete: mark the main task complete.
+
+### 2.7 PR rules
 
 - PR always toward `main`, **never push directly to main**.
 - Always open as a **draft** — human review is mandatory before merge.
@@ -221,7 +264,7 @@ gh issue view 123
 - Link the PR to the corresponding issue: `Closes #<issue-number>` in the PR description.
 - After opening the PR, return the URL to the user and stop.
 
-### 2.7 FORBIDDEN git commands (without explicit human approval)
+### 2.8 FORBIDDEN git commands (without explicit human approval)
 
 ```bash
 # NEVER run autonomously:
@@ -233,6 +276,55 @@ git push origin main
 ```
 
 If you need one of these, **explain the reason to the user and wait for written confirmation**.
+
+### 2.9 Changelog entry template (MANDATORY — step 4.5)
+
+Every push must be accompanied by a file in `docs/en/changelog/` following this naming convention:
+
+```
+docs/en/changelog/YYYY-MM-DD-X.Y.Z-<branch-name>.md
+```
+
+Where `X.Y.Z` is the version currently in `package.json` at the time of the push — always use the
+real version number, never a placeholder like `unreleased`.
+
+A corresponding Italian translation must be created in `docs/it/changelog/` with the same
+filename. **No Spanish translation** — changelogs are internal technical notes, not the library's
+public-facing documentation (unlike `README.md`/`DOCUMENTATION_ES.md`, see §4).
+
+**Template:**
+
+```markdown
+# <Descriptive title of the change>
+
+## Context
+Why this work was done — bug report, user request, or decision reached in a grilling session.
+
+## Tracking
+Link to the GitHub Issue(s) and the main Asana task/subtasks.
+
+## Branch & Version
+- **Branch:** `<branch-name>`
+- **Version:** `X.Y.Z` (or `unreleased`)
+
+## Files Changed
+| File | Change |
+|------|--------|
+| `path/to/file.jsx` | One-line description of what changed in this file |
+
+## Technical Changes
+Key snippets of the final code with a comment explaining the why, not the what.
+
+## Motivation
+The reasoning behind the chosen solution — why this approach and not another.
+```
+
+After creating the entry, add one line to the `CHANGELOG.md` master index under the correct
+version heading:
+
+```markdown
+- [branch-name](docs/en/changelog/YYYY-MM-DD-X.Y.Z-branch-name.md) — one-line description
+```
 
 ---
 
@@ -247,6 +339,7 @@ If you need one of these, **explain the reason to the user and wait for written 
 - **Notifications**: Sileo (mobile-optimized toast)
 - **Device detection**: `ua-parser-js`
 - **Calendar/holidays**: `date-holidays`
+- **SVG assets**: `vite-plugin-svgr` (import `.svg` files as React components)
 - **Lint**: ESLint 9
 
 ## Project structure
@@ -314,9 +407,12 @@ docs/
     utils/            # dateUtils, fetchAxiosConfig
     css/              # css-variables.md
     modal.md          # Full modal system guide (useModal API)
-  it/                 # Italian translations (mirrors en/ structure)
-  es/                 # Spanish translations (mirrors en/ structure)
-  adr/                # Architecture Decision Records
+    adr/              # Architecture Decision Records (English, primary)
+    changelog/        # One file per shipped change (English, primary — see §2.9)
+    releases/         # RELEASES.md — human-readable release notes (English, primary — see §5)
+  it/                 # Italian translations (mirrors en/ structure, including adr/, changelog/, releases/)
+  es/                 # Spanish translations (mirrors en/ component/hook/context docs only —
+                      # no adr/, changelog/, or releases/, see §4)
 deploy-scripts/     # Deployment utilities and Docker templates
 public/
   config.json       # Dev/test runtime configuration (not shipped in npm package)
@@ -366,21 +462,28 @@ git diff --cached | grep -iE "(password|secret|key|token|api_key|private)" && ec
 - **Commit messages** — already required by §2.4 (Conventional Commits in English).
 - **PR** — title, description, technical labels.
 
-**The only allowed exception:**
+**The only allowed exceptions:**
 
 - **End-user-facing strings (UI)** that must appear in a specific language for a product requirement.
+- **Asana task/subtask names and descriptions** (§2.6) — always Italian, an internal team-tracking
+  convention unrelated to the repo's own code/docs language.
 
-**Markdown trilingual rule:**
+**Markdown translation rule — scope differs by document type:**
 
-Every `.md` document must be written in **English** as the primary language. For each primary `.md`
-file created or updated, the corresponding Italian and Spanish translations must be created or updated:
+The library's **public-facing** documentation is trilingual (EN primary, IT/ES translations) since
+external consumers read it. **Internal** engineering-process documentation (changelogs, ADRs) is
+only EN+IT, since it has no audience outside the Bancolini team maintaining this repo.
 
 | Primary (English) | Italian | Spanish |
 |---|---|---|
 | `AGENTS.md` | `docs/it/AGENTS.md` | `docs/es/AGENTS.md` |
 | `README.md` | `DOCUMENTATION_IT.md` | `DOCUMENTATION_ES.md` |
+| `docs/en/**` (component/hook/context reference) | `docs/it/**` | `docs/es/**` |
+| `docs/en/adr/*.md` | `docs/it/adr/*.md` | *(none)* |
+| `docs/en/changelog/*.md` | `docs/it/changelog/*.md` | *(none)* |
+| `docs/en/releases/RELEASES.md` | `docs/it/releases/RELEASES.md` | *(none)* |
 
-All three versions must remain in sync after every update.
+All versions in a row must remain in sync after every update.
 
 ```javascript
 // ✅ CORRECT
@@ -394,26 +497,38 @@ function formattaEtichettaData(voce) { /* ... */ }
 
 ## 5. VERSIONING
 
-The version lives in `package.json`. Each version bump corresponds to a commit with
-message `X.Y.Z` + update to `CHANGELOG.md`.
+The version lives in `package.json`. Each version bump is a deliberate decision made by the
+user — the agent must never bump the version autonomously.
+
+**When the user asks to bump the version, follow this sequence in order:**
+
+1. Write the release summary in `docs/en/releases/RELEASES.md` (human-readable, top of file):
+   - Add a `## [X.Y.Z] — YYYY-MM-DD` heading
+   - Summarize what changed in plain language
+   - Link to the relevant `docs/en/changelog/` entries for technical details
+2. Create the Italian translation in `docs/it/releases/RELEASES.md` (no Spanish, see §4)
+3. Create a standalone Asana task `Release X.Y.Z` (§2.6) in the current sprint section:
+   - Assignee: `"me"`
+   - Description: the content written in step 1, **written in Italian**
+   - **Immediately mark it as completed** — the release is already live at this point
+4. Run the version bump command:
 
 ```bash
 npm run increment-version   # bump patch + git push
 ```
 
-After every version bump, update the version number in `README.md`, `DOCUMENTATION_IT.md`,
-and `DOCUMENTATION_ES.md`.
+5. Update the version number in `README.md`, `DOCUMENTATION_IT.md`, and `DOCUMENTATION_ES.md`.
 
 ---
 
 ## 6. ARCHITECTURE DECISION RECORDS
 
-Architectural decisions live in `docs/adr/`.
-Format: `docs/adr/NNNN-<kebab-title>.md` (Lightweight ADR, Michael Nygard).
+Architectural decisions live in `docs/en/adr/`, translated to `docs/it/adr/` (no Spanish, see §4).
+Format: `docs/en/adr/NNNN-<kebab-title>.md` (Lightweight ADR, Michael Nygard).
 
 When you make a decision that impacts the architecture:
-1. Create or update the corresponding ADR.
-2. Commit it in the same PR as the change that motivated the decision.
+1. Create or update the corresponding ADR (English) and its Italian translation.
+2. Commit both in the same PR as the change that motivated the decision.
 3. Update `CONTEXT.md` if the decision introduces new domain language.
 
 ---
@@ -428,9 +543,12 @@ Before every `git push`, verify:
 - [ ] Are code and code comments in English?
 - [ ] No secrets or credentials in the diff?
 - [ ] Does the corresponding GitHub Issue exist and is referenced in the PR?
+- [ ] Does the corresponding Asana task/subtask exist, in the current sprint of "Sviluppo Sprint"?
+- [ ] Did I create the changelog entry in `docs/en/changelog/` and its Italian translation? (step 4.5)
+- [ ] Did I update the `CHANGELOG.md` master index with a link + one-line summary?
 - [ ] Is the PR targeted at `main`?
 - [ ] Is the PR opened as a draft?
-- [ ] Are all three documentation languages (EN, IT, ES) updated if docs changed?
+- [ ] Are the relevant documentation languages updated? (EN+IT+ES for public docs, EN+IT for changelog/ADR/releases, see §4)
 
 ---
 
@@ -460,8 +578,10 @@ Before every `git push`, verify:
 After every significant change, update:
 1. `README.md` + `DOCUMENTATION_IT.md` + `DOCUMENTATION_ES.md` — if public API, props, hooks, or config changes
 2. `AGENTS.md` + `docs/it/AGENTS.md` + `docs/es/AGENTS.md` — if architecture or conventions change
-3. `README.md` — if installation steps or package-level behavior changes
-4. `CHANGELOG.md` — always, with today's date and current version
+3. `docs/en/changelog/YYYY-MM-DD-X.Y.Z-branch.md` + `docs/it/changelog/` — always (§2.9)
+4. `CHANGELOG.md` — always, with a link to the new changelog entry
+5. `docs/en/adr/` + `docs/it/adr/` — only when the change carries an architectural decision (§6)
+6. `docs/en/releases/RELEASES.md` + `docs/it/releases/RELEASES.md` — only on version bumps (§5)
 
 ---
 
@@ -473,3 +593,4 @@ After every significant change, update:
 - Do not push directly to `main`
 - Do not merge PRs autonomously
 - Do not publish to npm (`npm publish`) without explicit human approval
+- Do not create Asana tasks in any project other than "Sviluppo Sprint" for this repo

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+Master index of every change tracked under `docs/en/changelog/` (see [AGENTS.md §2.9](AGENTS.md#29-changelog-entry-template-mandatory--step-45)
+for the process). Each entry links to the detailed English changelog file; an Italian translation
+of every entry lives under `docs/it/changelog/`.
+
+## 0.0.217
+
+- [docs-rewrite-agents-for-thecore-auth](docs/en/changelog/2026-07-29-0.0.217-docs-rewrite-agents-for-thecore-auth.md) — rewrite AGENTS.md (+ IT/ES translations) so it reflects thecore-auth instead of the Bancolini planner app it had been overwritten with

--- a/docs/en/changelog/2026-07-29-0.0.217-docs-rewrite-agents-for-thecore-auth.md
+++ b/docs/en/changelog/2026-07-29-0.0.217-docs-rewrite-agents-for-thecore-auth.md
@@ -1,0 +1,46 @@
+# Rewrite AGENTS.md so it fits thecore-auth instead of the Bancolini planner app
+
+## Context
+`AGENTS.md` had been locally overwritten with content copied from a different project (the
+Bancolini planner app): roleGuard/admin-impersonation ("manutentore") rules, Free Tasks /
+Communications / Gantt ("planner") module maps, chrome-devtools-mcp browser-verification steps,
+and a `release/3` + GitLab git workflow — none of which apply to this repo. A grilling session
+settled the open questions before the rewrite (Asana coexists with GitHub Issues rather than
+replacing it; changelog/ADR/release-notes get a per-change file structure in EN+IT only, not ES;
+browser verification is dropped entirely, since this repo has no app to browser-test).
+
+## Tracking
+GitHub Issue: not created — `gh` is not authenticated in this environment (`gh auth login`
+required). Asana task/subtask: not created — no Asana MCP tool was connected in this session. Both
+need to be created manually (or this session re-run once the tools are connected) to satisfy the
+traceability rule this same change introduces.
+
+## Branch & Version
+- **Branch:** `docs/rewrite-agents-for-thecore-auth`
+- **Version:** `0.0.217`
+
+## Files Changed
+| File | Change |
+|------|--------|
+| `AGENTS.md` | Restored the thecore-auth-specific content (main-branch git workflow, real tech stack/module map) that had been overwritten with Bancolini planner content; added Asana tracking (§2.6), the changelog process (§2.9), the richer versioning process (§5), and the docs/en/adr + docs/it/adr split (§6); removed the browser-verification section entirely |
+| `docs/it/AGENTS.md` | Italian translation of the same rewrite |
+| `docs/es/AGENTS.md` | Spanish translation of the same rewrite |
+| `docs/en/changelog/2026-07-29-0.0.217-docs-rewrite-agents-for-thecore-auth.md` | This entry |
+| `docs/it/changelog/2026-07-29-0.0.217-docs-rewrite-agents-for-thecore-auth.md` | Italian translation of this entry |
+| `CHANGELOG.md` | Created the master changelog index (did not exist before) and added the first entry |
+
+## Technical Changes
+No code changes — this is a `docs`-classified change per AGENTS.md §1.0, affecting only
+`AGENTS.md` and its translations, plus establishing the changelog/ADR/release-notes folder
+structure (`docs/en/{adr,changelog,releases}/` + `docs/it/{adr,changelog,releases}/`) that this
+same change now mandates going forward.
+
+## Motivation
+Keeping a wrong `AGENTS.md` in place would have every future agent session on this repo follow
+rules for a codebase it isn't operating on (admin-impersonation configs, Gantt/Free-Task module
+maps, a `release/3` branch that doesn't exist here). The heavier structural additions (Asana
+alongside GitHub Issues, per-change changelog files, ADR translation) were adopted from the
+Bancolini planner's process on the grilling session's recommendation — mirroring proven,
+al­ready-in-use team conventions rather than inventing a new process from scratch — with a
+narrower language scope (EN+IT, no ES) since these are internal engineering-process documents, not
+the library's public-facing documentation.

--- a/docs/es/AGENTS.md
+++ b/docs/es/AGENTS.md
@@ -34,10 +34,10 @@ Antes de hacer cualquier cosa, clasifica la solicitud en uno de estos tipos:
 | `code` | `src/`, dependencias, tests | ✅ Sí — Pasos 1–5 |
 | `config` | `public/config.json`, `vite.config.js` | ✅ Sí — Pasos 1–5 |
 | `docs` | `AGENTS.md`, `.claude/skills/`, `.claude/settings.json` hooks | ✅ Sí — Pasos 1–5 |
-| `readme` | `README.md`, `CHANGELOG.md`, traducciones | Paso 1 ligero + actualización de traducciones |
+| `readme` | `README.md`, `CHANGELOG.md`, `DOCUMENTATION_IT.md`/`DOCUMENTATION_ES.md` | Paso 1 ligero + actualización de traducciones |
 
 **Por qué `config` y `docs` requieren el flujo completo:**
-- Los cambios en `public/config.json` afectan el comportamiento en tiempo de ejecución de la app.
+- Los cambios en `public/config.json` afectan el comportamiento en tiempo de ejecución de la app demo de dev/test.
 - Los cambios en `AGENTS.md` afectan cada sesión de IA futura en este repo — una regla incorrecta se propaga en todas partes.
 - Skills y hooks cambian lo que la IA hace automáticamente — mismo nivel de riesgo que el código.
 
@@ -53,13 +53,19 @@ PASO 2 ─ ¿Puedes resolver todo en conversación?
           NO → /prototype (sesión desechable) → /handoff (trae el resultado) → vuelve al PASO 1
 
 PASO 3 ─ ¿Es una construcción multi-sesión? (> 1 issue, > 1 componente, estimación > 2h)
-          SÍ → /to-prd   (PRD como issue)
+          SÍ → /to-prd   (PRD como GitHub Issue)
                /to-issues (divide en issues independientes, verticalmente segmentadas)
                Luego: una NUEVA sesión por issue → /implement con PRD + issue única
           NO → /implement en la misma ventana de contexto
 
 PASO 4 ─ Flujo de Git (ver §2)
           Feature branch → commits atómicos → PR hacia main → stop, sin merge autónomo
+
+PASO 4.5 ─ Changelog (ver §2.9) — OBLIGATORIO antes de cada push
+            1. Crea docs/en/changelog/YYYY-MM-DD-X.Y.Z-branch-name.md usando la plantilla del §2.9
+            2. Actualiza el índice maestro CHANGELOG.md con un enlace + un resumen de una línea
+            3. Crea la traducción italiana en docs/it/changelog/
+            No hagas push antes de completar este paso.
 
 PASO 5 ─ /tdd
           Cada implementación sigue el ciclo rojo-verde-refactor.
@@ -79,7 +85,7 @@ PASO 5 ─ /tdd
 ```
 ¿Tienes un momento libre entre tareas? Ejecuta:
 → /improve-codebase-architecture
-   Lee CONTEXT.md y docs/adr/ e identifica oportunidades de profundización.
+   Lee CONTEXT.md y docs/en/adr/ e identifica oportunidades de profundización.
    Cada oportunidad se convierte en una idea → regresa al flujo principal en el PASO 1.
 ```
 
@@ -180,7 +186,8 @@ BREAKING CHANGE: añade como footer o con ! después del tipo
 
 ### 2.5 GitHub Issues — seguimiento de issues y tareas (OBLIGATORIO)
 
-Este proyecto usa **GitHub Issues** como rastreador de issues.
+Este proyecto usa **GitHub Issues** como rastreador de issues, junto con Asana (ver §2.6) — ambos
+son obligatorios, no alternativas.
 Repositorio: [https://github.com/SantiGalvan/thecore-auth](https://github.com/SantiGalvan/thecore-auth)
 
 **Cada implementación debe tener una GitHub Issue correspondiente.**
@@ -198,8 +205,9 @@ Repositorio: [https://github.com/SantiGalvan/thecore-auth](https://github.com/Sa
 3. Al terminar: cierra la issue a través de la descripción de la PR (`Closes #123`).
 
 **Regla de trazabilidad obligatoria:**
-Cada cambio en el codebase — por pequeño que sea — debe tener una GitHub Issue correspondiente.
-Antes de terminar una sesión, verifica que todos los cambios estén rastreados. Crea cualquier issue faltante de inmediato.
+Cada cambio en el codebase — por pequeño que sea — debe tener una GitHub Issue correspondiente **y**
+un subtask de Asana correspondiente (§2.6). Antes de terminar una sesión, verifica que todos los
+cambios estén rastreados en ambos sistemas. Crea cualquier issue/subtask faltante de inmediato.
 
 **GitHub CLI:**
 ```bash
@@ -213,7 +221,44 @@ gh issue list
 gh issue view 123
 ```
 
-### 2.6 Reglas para las PR
+### 2.6 Asana — seguimiento de sprint (OBLIGATORIO)
+
+Cada GitHub Issue anterior también obtiene una tarea de Asana correspondiente, para que el tablero
+de sprint del equipo refleje el trabajo hecho en este repo. Las tareas de Asana son **además de**
+GitHub Issues, no un reemplazo.
+
+**Proyecto: siempre "Sviluppo Sprint" — nunca "MyTask"** (ese proyecto pertenece a la app planner
+de Bancolini, un codebase diferente). No preguntes al usuario qué proyecto usar — es fijo.
+
+**Cómo resolver el proyecto y el sprint actual (sin GIDs hardcodeados — búscalos cada vez):**
+1. Llama a la herramienta de listado de workspaces para encontrar el GID del workspace `bancolini.com`.
+2. Llama a `asana_get_projects_for_workspace` en ese workspace y encuentra el proyecto llamado
+   **"Sviluppo Sprint"** por nombre — nunca asumas que su GID es estable entre sesiones.
+3. Llama a `asana_get_project_sections` en el GID de ese proyecto.
+4. Encuentra la sección llamada `Sprint DD Mmm–DD Mmm YYYY` cuyo rango de fechas incluya hoy.
+   **Usa siempre el sprint actual.** Nunca uses el Backlog a menos que no exista ninguna sección
+   de sprint activa.
+
+**Estructura para cada implementación:**
+- **Tarea principal** → una tarea por implementación, nombrada en italiano como una descripción
+  simple sin prefijo Conventional Commits (ej. `Aggiunta traduzione spagnola alla documentazione`,
+  no `docs(readme): add spanish translation`).
+- **Subtareas** → una subtarea por cada GitHub Issue de esta implementación, referenciando el
+  número de la issue (ej. `Tradurre AGENTS.md in spagnolo (#42)`).
+
+**Reglas para cada tarea y subtarea creada:**
+- **Idioma**: nombres y descripciones de las tareas siempre en **italiano** (es una herramienta
+  interna de seguimiento del equipo Bancolini — independiente de la
+  [regla del inglés](#4-reglas-de-idioma-obligatorio) que rige el código y la documentación del repo).
+- **Asignado**: siempre `"me"`.
+- **Sección**: siempre la sección del sprint actual (ver arriba).
+
+**Ciclo de vida:**
+1. Antes de comenzar: crea la tarea principal + una subtarea por cada GitHub Issue.
+2. Durante el trabajo: marca cada subtarea como completa cuando su GitHub Issue se cierre.
+3. Cuando todas las subtareas estén completas: marca la tarea principal como completa.
+
+### 2.7 Reglas para las PR
 
 - La PR siempre hacia `main`, **nunca hacer push directo a main**.
 - Siempre abrir como **draft** — la revisión humana es obligatoria antes del merge.
@@ -221,7 +266,7 @@ gh issue view 123
 - Enlaza la PR a la issue correspondiente: `Closes #<número-issue>` en la descripción.
 - Después de abrir la PR, devuelve la URL al usuario y detente.
 
-### 2.7 Comandos git PROHIBIDOS (sin aprobación humana explícita)
+### 2.8 Comandos git PROHIBIDOS (sin aprobación humana explícita)
 
 ```bash
 # NUNCA ejecutar autónomamente:
@@ -233,6 +278,57 @@ git push origin main
 ```
 
 Si necesitas uno de estos, **explica el motivo al usuario y espera confirmación escrita**.
+
+### 2.9 Plantilla de entrada de changelog (OBLIGATORIO — paso 4.5)
+
+Cada push debe ir acompañado de un archivo en `docs/en/changelog/` siguiendo esta convención de
+nombres:
+
+```
+docs/en/changelog/YYYY-MM-DD-X.Y.Z-<branch-name>.md
+```
+
+Donde `X.Y.Z` es la versión actual en `package.json` en el momento del push — usa siempre el
+número de versión real, nunca un placeholder como `unreleased`.
+
+Se debe crear una traducción italiana correspondiente en `docs/it/changelog/` con el mismo nombre
+de archivo. **Sin traducción al español** — los changelogs son notas técnicas internas, no
+documentación pública de la librería (a diferencia de `README.md`/`DOCUMENTATION_ES.md`, ver §4).
+
+**Plantilla:**
+
+```markdown
+# <Título descriptivo del cambio>
+
+## Contexto
+Por qué se hizo este trabajo — bug report, solicitud del usuario, o decisión alcanzada en una
+sesión de grilling.
+
+## Seguimiento
+Enlace a la(s) GitHub Issue(s) y a la tarea/subtareas principales de Asana.
+
+## Rama y versión
+- **Rama:** `<branch-name>`
+- **Versión:** `X.Y.Z` (o `unreleased`)
+
+## Archivos modificados
+| Archivo | Cambio |
+|---------|--------|
+| `path/to/file.jsx` | Descripción de una línea de qué cambió en este archivo |
+
+## Cambios técnicos
+Fragmentos clave del código final con un comentario que explica el porqué, no el qué.
+
+## Motivación
+El razonamiento detrás de la solución elegida — por qué este enfoque y no otro.
+```
+
+Después de crear la entrada, añade una línea al índice maestro `CHANGELOG.md` bajo el encabezado
+de versión correcto:
+
+```markdown
+- [branch-name](docs/en/changelog/YYYY-MM-DD-X.Y.Z-branch-name.md) — descripción de una línea
+```
 
 ---
 
@@ -247,6 +343,7 @@ Si necesitas uno de estos, **explica el motivo al usuario y espera confirmación
 - **Notificaciones**: Sileo (toast optimizados para mobile)
 - **Detección de dispositivo**: `ua-parser-js`
 - **Calendario/festivos**: `date-holidays`
+- **Assets SVG**: `vite-plugin-svgr` (importa archivos `.svg` como componentes React)
 - **Lint**: ESLint 9
 
 ## Estructura del proyecto
@@ -314,9 +411,12 @@ docs/
     utils/            # dateUtils, fetchAxiosConfig
     css/              # css-variables.md
     modal.md          # Guía completa del sistema modal (API useModal)
-  it/                 # Traducciones al italiano (espeja la estructura en/)
-  es/                 # Traducciones al español (espeja la estructura en/)
-  adr/                # Architecture Decision Records
+    adr/              # Architecture Decision Records (inglés, primario)
+    changelog/        # Un archivo por cada cambio publicado (inglés, primario — ver §2.9)
+    releases/         # RELEASES.md — notas de lanzamiento legibles (inglés, primario — ver §5)
+  it/                 # Traducciones al italiano (espeja la estructura en/, incluyendo adr/, changelog/, releases/)
+  es/                 # Traducciones al español (espeja solo la doc de componentes/hooks/context de en/ —
+                      # sin adr/, changelog/, ni releases/, ver §4)
 deploy-scripts/     # Utilidades de deploy y templates Docker
 public/
   config.json       # Configuración runtime para dev/test (no incluida en el paquete npm)
@@ -366,21 +466,28 @@ git diff --cached | grep -iE "(password|secret|key|token|api_key|private)" && ec
 - **Mensajes de commit** — ya requerido por §2.4 (Conventional Commits en inglés).
 - **PR** — título, descripción, etiquetas técnicas.
 
-**La única excepción permitida:**
+**Únicas excepciones permitidas:**
 
 - **Strings visibles para el usuario final (UI)** que deben aparecer en un idioma específico por un requisito de producto.
+- **Nombres y descripciones de tareas/subtareas de Asana** (§2.6) — siempre en italiano, una
+  convención interna del equipo independiente del idioma del código/documentación del repo.
 
-**Regla trilingüe para Markdown:**
+**Regla de traducción de Markdown — el alcance varía según el tipo de documento:**
 
-Cada archivo `.md` debe escribirse en **inglés** como idioma principal. Para cada archivo `.md` primario
-creado o actualizado, las traducciones al italiano y español correspondientes deben crearse o actualizarse:
+La documentación **pública** de la librería es trilingüe (EN principal, traducciones IT/ES) porque
+la leen consumidores externos. La documentación **interna** de proceso de ingeniería (changelogs,
+ADR) es solo EN+IT, ya que no tiene audiencia fuera del equipo Bancolini que mantiene este repo.
 
-| Primario (Inglés) | Italiano | Español |
+| Principal (Inglés) | Italiano | Español |
 |---|---|---|
 | `AGENTS.md` | `docs/it/AGENTS.md` | `docs/es/AGENTS.md` |
 | `README.md` | `DOCUMENTATION_IT.md` | `DOCUMENTATION_ES.md` |
+| `docs/en/**` (referencia componentes/hooks/context) | `docs/it/**` | `docs/es/**` |
+| `docs/en/adr/*.md` | `docs/it/adr/*.md` | *(ninguna)* |
+| `docs/en/changelog/*.md` | `docs/it/changelog/*.md` | *(ninguna)* |
+| `docs/en/releases/RELEASES.md` | `docs/it/releases/RELEASES.md` | *(ninguna)* |
 
-Las tres versiones deben mantenerse sincronizadas después de cada actualización.
+Todas las versiones de una fila deben mantenerse sincronizadas después de cada actualización.
 
 ```javascript
 // ✅ CORRECTO
@@ -394,26 +501,40 @@ function formatearEtiquetaFecha(entrada) { /* ... */ }
 
 ## 5. VERSIONADO
 
-La versión vive en `package.json`. Cada bump de versión corresponde a un commit con
-mensaje `X.Y.Z` + actualización de `CHANGELOG.md`.
+La versión vive en `package.json`. Cada bump de versión es una decisión deliberada tomada por el
+usuario — el agente nunca debe hacer el bump de versión de forma autónoma.
+
+**Cuando el usuario pida hacer el bump de versión, sigue esta secuencia en orden:**
+
+1. Escribe el resumen del lanzamiento en `docs/en/releases/RELEASES.md` (legible, en la parte
+   superior del archivo):
+   - Añade un encabezado `## [X.Y.Z] — YYYY-MM-DD`
+   - Resume qué cambió en lenguaje simple
+   - Enlaza a las entradas relevantes de `docs/en/changelog/` para los detalles técnicos
+2. Crea la traducción italiana en `docs/it/releases/RELEASES.md` (sin español, ver §4)
+3. Crea una tarea de Asana independiente `Release X.Y.Z` (§2.6) en la sección del sprint actual:
+   - Asignado: `"me"`
+   - Descripción: el contenido escrito en el paso 1, **escrito en italiano**
+   - **Márcala como completada de inmediato** — el lanzamiento ya está en vivo en este punto
+4. Ejecuta el comando de bump de versión:
 
 ```bash
 npm run increment-version   # bump patch + git push
 ```
 
-Después de cada bump de versión, actualiza el número de versión en `README.md`, `DOCUMENTATION_IT.md`
-y `DOCUMENTATION_ES.md`.
+5. Actualiza el número de versión en `README.md`, `DOCUMENTATION_IT.md` y `DOCUMENTATION_ES.md`.
 
 ---
 
 ## 6. ARCHITECTURE DECISION RECORDS
 
-Las decisiones arquitectónicas se encuentran en `docs/adr/`.
-Formato: `docs/adr/NNNN-<kebab-title>.md` (Lightweight ADR, Michael Nygard).
+Las decisiones arquitectónicas se encuentran en `docs/en/adr/`, traducidas a `docs/it/adr/` (sin
+español, ver §4).
+Formato: `docs/en/adr/NNNN-<kebab-title>.md` (Lightweight ADR, Michael Nygard).
 
 Cuando tomes una decisión que impacte la arquitectura:
-1. Crea o actualiza el ADR correspondiente.
-2. Haz commit en la misma PR que el cambio que motivó la decisión.
+1. Crea o actualiza el ADR correspondiente (inglés) y su traducción italiana.
+2. Haz commit de ambos en la misma PR que el cambio que motivó la decisión.
 3. Actualiza `CONTEXT.md` si la decisión introduce nuevo lenguaje de dominio.
 
 ---
@@ -428,9 +549,13 @@ Antes de cada `git push`, verifica:
 - [ ] ¿El código y los comentarios están en inglés?
 - [ ] ¿No hay secretos o credenciales en el diff?
 - [ ] ¿Existe la GitHub Issue correspondiente y está referenciada en la PR?
+- [ ] ¿Existe la tarea/subtarea de Asana correspondiente, en el sprint actual de "Sviluppo Sprint"?
+- [ ] ¿Creé la entrada de changelog en `docs/en/changelog/` y su traducción italiana? (paso 4.5)
+- [ ] ¿Actualicé el índice maestro `CHANGELOG.md` con un enlace + un resumen de una línea?
 - [ ] ¿La PR apunta a `main`?
 - [ ] ¿La PR está abierta como draft?
-- [ ] ¿Los tres idiomas de la documentación (EN, IT, ES) están actualizados si cambió la doc?
+- [ ] ¿Los idiomas de documentación relevantes están actualizados? (EN+IT+ES para doc pública,
+      EN+IT para changelog/ADR/lanzamientos, ver §4)
 
 ---
 
@@ -460,8 +585,10 @@ Antes de cada `git push`, verifica:
 Después de cada cambio significativo, actualiza:
 1. `README.md` + `DOCUMENTATION_IT.md` + `DOCUMENTATION_ES.md` — si cambia la API pública, props, hooks o configuración
 2. `AGENTS.md` + `docs/it/AGENTS.md` + `docs/es/AGENTS.md` — si cambia la arquitectura o las convenciones
-3. `README.md` — si cambian los pasos de instalación o el comportamiento a nivel de paquete
-4. `CHANGELOG.md` — siempre, con la fecha de hoy y la versión actual
+3. `docs/en/changelog/YYYY-MM-DD-X.Y.Z-branch.md` + `docs/it/changelog/` — siempre (§2.9)
+4. `CHANGELOG.md` — siempre, con un enlace a la nueva entrada de changelog
+5. `docs/en/adr/` + `docs/it/adr/` — solo cuando el cambio conlleva una decisión arquitectónica (§6)
+6. `docs/en/releases/RELEASES.md` + `docs/it/releases/RELEASES.md` — solo en bumps de versión (§5)
 
 ---
 
@@ -473,3 +600,4 @@ Después de cada cambio significativo, actualiza:
 - No hacer push directamente a `main`
 - No hacer merge de PRs autónomamente
 - No publicar en npm (`npm publish`) sin aprobación humana explícita
+- No crear tareas de Asana en ningún proyecto distinto de "Sviluppo Sprint" para este repo

--- a/docs/it/AGENTS.md
+++ b/docs/it/AGENTS.md
@@ -34,10 +34,10 @@ Prima di fare qualsiasi cosa, classifica la richiesta in uno di questi tipi:
 | `code` | `src/`, dipendenze, test | ✅ Sì — Step 1–5 |
 | `config` | `public/config.json`, `vite.config.js` | ✅ Sì — Step 1–5 |
 | `docs` | `AGENTS.md`, `.claude/skills/`, `.claude/settings.json` hook | ✅ Sì — Step 1–5 |
-| `readme` | `README.md`, `CHANGELOG.md`, traduzioni | Step 1 leggero + aggiornamento traduzioni |
+| `readme` | `README.md`, `CHANGELOG.md`, `DOCUMENTATION_IT.md`/`DOCUMENTATION_ES.md` | Step 1 leggero + aggiornamento traduzioni |
 
 **Perché `config` e `docs` richiedono il flusso completo:**
-- Le modifiche a `public/config.json` influenzano il comportamento runtime dell'app.
+- Le modifiche a `public/config.json` influenzano il comportamento runtime dell'app demo di dev/test.
 - Le modifiche a `AGENTS.md` influenzano ogni sessione AI futura su questo repo — una regola errata si propaga ovunque.
 - Skill e hook cambiano ciò che l'AI fa automaticamente — stesso livello di rischio del codice.
 
@@ -53,13 +53,19 @@ STEP 2 ─ Puoi risolvere tutto in conversazione?
           NO  → /prototype (sessione usa e getta) → /handoff (riporta il risultato) → torna allo STEP 1
 
 STEP 3 ─ È una build multi-sessione? (> 1 issue, > 1 componente, stima > 2h)
-          SÌ  → /to-prd   (PRD come issue)
+          SÌ  → /to-prd   (PRD come GitHub Issue)
                 /to-issues (split in issue indipendenti, verticalmente sliced)
                 Poi: una NUOVA sessione per issue → /implement con PRD + singola issue
           NO  → /implement nella stessa finestra di contesto
 
 STEP 4 ─ Git workflow (vedi §2)
           Feature branch → commit atomici → PR verso main → stop, nessun merge autonomo
+
+STEP 4.5 ─ Changelog (vedi §2.9) — OBBLIGATORIO prima di ogni push
+            1. Crea docs/en/changelog/YYYY-MM-DD-X.Y.Z-branch-name.md usando il template al §2.9
+            2. Aggiorna l'indice master CHANGELOG.md con un link + una riga di riepilogo
+            3. Crea la traduzione italiana in docs/it/changelog/
+            Non fare push prima che questo step sia completo.
 
 STEP 5 ─ /tdd
           Ogni implementazione segue il ciclo red-green-refactor.
@@ -79,7 +85,7 @@ Bug report / feature request ricevuto dall'esterno?
 ```
 Hai un momento libero tra un task e l'altro? Esegui:
 → /improve-codebase-architecture
-   Legge CONTEXT.md e docs/adr/ e identifica opportunità di miglioramento.
+   Legge CONTEXT.md e docs/en/adr/ e identifica opportunità di miglioramento.
    Ogni opportunità diventa un'idea → rientra nel flusso principale allo STEP 1.
 ```
 
@@ -180,7 +186,8 @@ BREAKING CHANGE: aggiungi come footer o con ! dopo il tipo
 
 ### 2.5 GitHub Issues — tracciamento di issue e task (OBBLIGATORIO)
 
-Questo progetto usa **GitHub Issues** come sistema di tracciamento.
+Questo progetto usa **GitHub Issues** come sistema di tracciamento, insieme ad Asana (vedi §2.6) —
+sono entrambi obbligatori, non alternative.
 Repository: [https://github.com/SantiGalvan/thecore-auth](https://github.com/SantiGalvan/thecore-auth)
 
 **Ogni implementazione deve avere una corrispondente GitHub Issue.**
@@ -198,8 +205,9 @@ Repository: [https://github.com/SantiGalvan/thecore-auth](https://github.com/San
 3. Al termine: chiudi la issue tramite la descrizione della PR (`Closes #123`).
 
 **Regola di tracciabilità obbligatoria:**
-Ogni modifica al codebase — per quanto piccola — deve avere una GitHub Issue corrispondente.
-Prima di terminare una sessione, verifica che tutte le modifiche siano tracciate. Crea eventuali issue mancanti immediatamente.
+Ogni modifica al codebase — per quanto piccola — deve avere una GitHub Issue corrispondente **e**
+un subtask Asana corrispondente (§2.6). Prima di terminare una sessione, verifica che tutte le
+modifiche siano tracciate in entrambi i sistemi. Crea eventuali issue/subtask mancanti immediatamente.
 
 **GitHub CLI:**
 ```bash
@@ -213,7 +221,44 @@ gh issue list
 gh issue view 123
 ```
 
-### 2.6 Regole per le PR
+### 2.6 Asana — tracciamento sprint (OBBLIGATORIO)
+
+Ogni GitHub Issue sopra ottiene anche un task Asana corrispondente, così la sprint board del team
+riflette il lavoro fatto su questo repo. I task Asana sono **in aggiunta a** GitHub Issues, non un
+sostituto.
+
+**Progetto: sempre "Sviluppo Sprint" — mai "MyTask"** (quel progetto appartiene all'app planner di
+Bancolini, un codebase diverso). Non chiedere all'utente quale progetto usare — è fisso.
+
+**Come risolvere progetto e sprint corrente (nessun GID hardcoded — cercali ogni volta):**
+1. Chiama lo strumento di elenco workspace per trovare il GID del workspace `bancolini.com`.
+2. Chiama `asana_get_projects_for_workspace` su quel workspace e trova il progetto chiamato
+   **"Sviluppo Sprint"** per nome — non assumere mai che il suo GID sia stabile tra sessioni.
+3. Chiama `asana_get_project_sections` sul GID di quel progetto.
+4. Trova la sezione chiamata `Sprint DD Mmm–DD Mmm YYYY` il cui intervallo di date include oggi.
+   **Usa sempre lo sprint corrente.** Non usare mai il Backlog a meno che non esista nessuna
+   sezione sprint attiva.
+
+**Struttura per ogni implementazione:**
+- **Task principale** → un task per implementazione, nominato in italiano come descrizione semplice
+  senza prefisso Conventional Commits (es. `Aggiunta traduzione spagnola alla documentazione`, non
+  `docs(readme): add spanish translation`).
+- **Subtask** → un subtask per ogni GitHub Issue di questa implementazione, che referenzia il numero
+  della issue (es. `Tradurre AGENTS.md in spagnolo (#42)`).
+
+**Regole per ogni task e subtask creato:**
+- **Lingua**: nomi e descrizioni dei task sempre in **italiano** (è uno strumento interno di
+  tracciamento del team Bancolini — indipendente dalla [regola inglese](#4-regole-di-lingua-obbligatorio)
+  che governa il codice e la documentazione del repo).
+- **Assegnatario**: sempre `"me"`.
+- **Sezione**: sempre la sezione dello sprint corrente (vedi sopra).
+
+**Ciclo di vita:**
+1. Prima di iniziare: crea il task principale + un subtask per ogni GitHub Issue.
+2. Durante il lavoro: marca ogni subtask come completo quando la sua GitHub Issue viene chiusa.
+3. Quando tutti i subtask sono completi: marca il task principale come completo.
+
+### 2.7 Regole per le PR
 
 - La PR va sempre verso `main`, **non fare mai push diretto su main**.
 - Apri sempre come **draft** — la revisione umana è obbligatoria prima del merge.
@@ -221,7 +266,7 @@ gh issue view 123
 - Collega la PR alla issue corrispondente: `Closes #<numero-issue>` nella descrizione.
 - Dopo aver aperto la PR, restituisci l'URL all'utente e fermati.
 
-### 2.7 Comandi git VIETATI (senza esplicita approvazione umana)
+### 2.8 Comandi git VIETATI (senza esplicita approvazione umana)
 
 ```bash
 # NON eseguire mai autonomamente:
@@ -233,6 +278,57 @@ git push origin main
 ```
 
 Se hai bisogno di uno di questi, **spiega il motivo all'utente e aspetta conferma scritta**.
+
+### 2.9 Template entry di changelog (OBBLIGATORIO — step 4.5)
+
+Ogni push deve essere accompagnato da un file in `docs/en/changelog/` con questa convenzione di
+naming:
+
+```
+docs/en/changelog/YYYY-MM-DD-X.Y.Z-<branch-name>.md
+```
+
+Dove `X.Y.Z` è la versione attuale in `package.json` al momento del push — usa sempre il numero
+di versione reale, mai un placeholder come `unreleased`.
+
+Una corrispondente traduzione italiana deve essere creata in `docs/it/changelog/` con lo stesso
+nome file. **Nessuna traduzione spagnola** — i changelog sono note tecniche interne, non
+documentazione pubblica della libreria (a differenza di `README.md`/`DOCUMENTATION_ES.md`, vedi §4).
+
+**Template:**
+
+```markdown
+# <Titolo descrittivo della modifica>
+
+## Contesto
+Perché è stato fatto questo lavoro — bug report, richiesta utente, o decisione presa in una
+sessione di grilling.
+
+## Tracciamento
+Link alla/e GitHub Issue e al task/subtask Asana principale.
+
+## Branch & Versione
+- **Branch:** `<branch-name>`
+- **Versione:** `X.Y.Z` (o `unreleased`)
+
+## File modificati
+| File | Modifica |
+|------|----------|
+| `path/to/file.jsx` | Descrizione in una riga di cosa è cambiato in questo file |
+
+## Modifiche tecniche
+Snippet chiave del codice finale con un commento che spiega il perché, non il cosa.
+
+## Motivazione
+Il ragionamento dietro la soluzione scelta — perché questo approccio e non un altro.
+```
+
+Dopo aver creato l'entry, aggiungi una riga all'indice master `CHANGELOG.md` sotto l'intestazione
+di versione corretta:
+
+```markdown
+- [branch-name](docs/en/changelog/YYYY-MM-DD-X.Y.Z-branch-name.md) — descrizione in una riga
+```
 
 ---
 
@@ -247,6 +343,7 @@ Se hai bisogno di uno di questi, **spiega il motivo all'utente e aspetta conferm
 - **Notifiche**: Sileo (toast ottimizzati per mobile)
 - **Rilevamento dispositivo**: `ua-parser-js`
 - **Calendario/festività**: `date-holidays`
+- **Asset SVG**: `vite-plugin-svgr` (importa i file `.svg` come componenti React)
 - **Lint**: ESLint 9
 
 ## Struttura del progetto
@@ -314,9 +411,12 @@ docs/
     utils/            # dateUtils, fetchAxiosConfig
     css/              # css-variables.md
     modal.md          # Guida completa al sistema modal (API useModal)
-  it/                 # Traduzioni in italiano (specchia la struttura en/)
-  es/                 # Traduzioni in spagnolo (specchia la struttura en/)
-  adr/                # Architecture Decision Records
+    adr/              # Architecture Decision Records (inglese, primario)
+    changelog/        # Un file per ogni modifica rilasciata (inglese, primario — vedi §2.9)
+    releases/         # RELEASES.md — note di rilascio leggibili (inglese, primario — vedi §5)
+  it/                 # Traduzioni in italiano (specchia la struttura en/, incluso adr/, changelog/, releases/)
+  es/                 # Traduzioni in spagnolo (specchia solo la doc componenti/hook/context di en/ —
+                      # niente adr/, changelog/, o releases/, vedi §4)
 deploy-scripts/     # Utility di deploy e template Docker
 public/
   config.json       # Configurazione runtime per dev/test (non inclusa nel pacchetto npm)
@@ -366,21 +466,28 @@ git diff --cached | grep -iE "(password|secret|key|token|api_key|private)" && ec
 - **Messaggi di commit** — già richiesto dal §2.4 (Conventional Commits in inglese).
 - **PR** — titolo, descrizione, label tecniche.
 
-**Unica eccezione consentita:**
+**Uniche eccezioni consentite:**
 
 - **Stringhe visibili all'utente finale (UI)** che devono apparire in una lingua specifica per un requisito di prodotto.
+- **Nomi e descrizioni di task/subtask Asana** (§2.6) — sempre in italiano, una convenzione interna
+  del team indipendente dalla lingua di codice/documentazione del repo.
 
-**Regola trilingue per il Markdown:**
+**Regola di traduzione Markdown — l'ambito varia per tipo di documento:**
 
-Ogni file `.md` deve essere scritto in **inglese** come lingua primaria. Per ogni file `.md` primario
-creato o aggiornato, le corrispondenti traduzioni in italiano e spagnolo devono essere create o aggiornate:
+La documentazione **pubblica** della libreria è trilingue (EN primario, traduzioni IT/ES) perché
+letta da consumer esterni. La documentazione **interna** di processo ingegneristico (changelog, ADR)
+è solo EN+IT, dato che non ha pubblico al di fuori del team Bancolini che mantiene questo repo.
 
 | Primario (Inglese) | Italiano | Spagnolo |
 |---|---|---|
 | `AGENTS.md` | `docs/it/AGENTS.md` | `docs/es/AGENTS.md` |
 | `README.md` | `DOCUMENTATION_IT.md` | `DOCUMENTATION_ES.md` |
+| `docs/en/**` (riferimento componenti/hook/context) | `docs/it/**` | `docs/es/**` |
+| `docs/en/adr/*.md` | `docs/it/adr/*.md` | *(nessuna)* |
+| `docs/en/changelog/*.md` | `docs/it/changelog/*.md` | *(nessuna)* |
+| `docs/en/releases/RELEASES.md` | `docs/it/releases/RELEASES.md` | *(nessuna)* |
 
-Tutte e tre le versioni devono rimanere sincronizzate dopo ogni aggiornamento.
+Tutte le versioni di una riga devono rimanere sincronizzate dopo ogni aggiornamento.
 
 ```javascript
 // ✅ CORRETTO
@@ -394,26 +501,39 @@ function formattaEtichettaData(voce) { /* ... */ }
 
 ## 5. VERSIONAMENTO
 
-La versione si trova in `package.json`. Ogni bump di versione corrisponde a un commit con
-messaggio `X.Y.Z` + aggiornamento di `CHANGELOG.md`.
+La versione si trova in `package.json`. Ogni bump di versione è una decisione deliberata presa
+dall'utente — l'agente non deve mai fare il bump di versione autonomamente.
+
+**Quando l'utente chiede di fare il bump di versione, segui questa sequenza in ordine:**
+
+1. Scrivi il riepilogo del rilascio in `docs/en/releases/RELEASES.md` (leggibile, in cima al file):
+   - Aggiungi un'intestazione `## [X.Y.Z] — YYYY-MM-DD`
+   - Riassumi cosa è cambiato in linguaggio semplice
+   - Collega alle voci `docs/en/changelog/` rilevanti per i dettagli tecnici
+2. Crea la traduzione italiana in `docs/it/releases/RELEASES.md` (nessuno spagnolo, vedi §4)
+3. Crea un task Asana standalone `Release X.Y.Z` (§2.6) nella sezione dello sprint corrente:
+   - Assegnatario: `"me"`
+   - Descrizione: il contenuto scritto allo step 1, **scritto in italiano**
+   - **Marcalo subito come completato** — il rilascio è già live a questo punto
+4. Esegui il comando di bump di versione:
 
 ```bash
 npm run increment-version   # bump patch + git push
 ```
 
-Dopo ogni bump di versione, aggiorna il numero di versione in `README.md`, `DOCUMENTATION_IT.md`
-e `DOCUMENTATION_ES.md`.
+5. Aggiorna il numero di versione in `README.md`, `DOCUMENTATION_IT.md` e `DOCUMENTATION_ES.md`.
 
 ---
 
 ## 6. ARCHITECTURE DECISION RECORDS
 
-Le decisioni architetturali si trovano in `docs/adr/`.
-Formato: `docs/adr/NNNN-<kebab-title>.md` (Lightweight ADR, Michael Nygard).
+Le decisioni architetturali si trovano in `docs/en/adr/`, tradotte in `docs/it/adr/` (nessuno
+spagnolo, vedi §4).
+Formato: `docs/en/adr/NNNN-<kebab-title>.md` (Lightweight ADR, Michael Nygard).
 
 Quando prendi una decisione che impatta l'architettura:
-1. Crea o aggiorna l'ADR corrispondente.
-2. Committa nella stessa PR della modifica che ha motivato la decisione.
+1. Crea o aggiorna l'ADR corrispondente (inglese) e la sua traduzione italiana.
+2. Committa entrambi nella stessa PR della modifica che ha motivato la decisione.
 3. Aggiorna `CONTEXT.md` se la decisione introduce nuovo linguaggio di dominio.
 
 ---
@@ -428,9 +548,13 @@ Prima di ogni `git push`, verifica:
 - [ ] Il codice e i commenti sono in inglese?
 - [ ] Nessun segreto o credenziale nel diff?
 - [ ] Esiste la GitHub Issue corrispondente ed è referenziata nella PR?
+- [ ] Esiste il task/subtask Asana corrispondente, nello sprint corrente di "Sviluppo Sprint"?
+- [ ] Ho creato l'entry di changelog in `docs/en/changelog/` e la sua traduzione italiana? (step 4.5)
+- [ ] Ho aggiornato l'indice master `CHANGELOG.md` con un link + una riga di riepilogo?
 - [ ] La PR è verso `main`?
 - [ ] La PR è aperta come draft?
-- [ ] Tutte e tre le lingue della documentazione (EN, IT, ES) sono aggiornate se la doc è cambiata?
+- [ ] Le lingue di documentazione rilevanti sono aggiornate? (EN+IT+ES per la doc pubblica, EN+IT
+      per changelog/ADR/release, vedi §4)
 
 ---
 
@@ -460,8 +584,10 @@ Prima di ogni `git push`, verifica:
 Dopo ogni modifica significativa, aggiorna:
 1. `README.md` + `DOCUMENTATION_IT.md` + `DOCUMENTATION_ES.md` — se l'API pubblica, le prop, gli hook o la configurazione cambiano
 2. `AGENTS.md` + `docs/it/AGENTS.md` + `docs/es/AGENTS.md` — se l'architettura o le convenzioni cambiano
-3. `README.md` — se cambiano i passi di installazione o il comportamento a livello di pacchetto
-4. `CHANGELOG.md` — sempre, con la data odierna e la versione corrente
+3. `docs/en/changelog/YYYY-MM-DD-X.Y.Z-branch.md` + `docs/it/changelog/` — sempre (§2.9)
+4. `CHANGELOG.md` — sempre, con un link alla nuova entry di changelog
+5. `docs/en/adr/` + `docs/it/adr/` — solo quando la modifica comporta una decisione architetturale (§6)
+6. `docs/en/releases/RELEASES.md` + `docs/it/releases/RELEASES.md` — solo sui bump di versione (§5)
 
 ---
 
@@ -473,3 +599,4 @@ Dopo ogni modifica significativa, aggiorna:
 - Non fare push direttamente su `main`
 - Non fare merge di PR autonomamente
 - Non pubblicare su npm (`npm publish`) senza esplicita approvazione umana
+- Non creare task Asana in nessun progetto diverso da "Sviluppo Sprint" per questo repo

--- a/docs/it/changelog/2026-07-29-0.0.217-docs-rewrite-agents-for-thecore-auth.md
+++ b/docs/it/changelog/2026-07-29-0.0.217-docs-rewrite-agents-for-thecore-auth.md
@@ -1,0 +1,48 @@
+# Riscrittura di AGENTS.md per adattarlo a thecore-auth invece che all'app planner di Bancolini
+
+## Contesto
+`AGENTS.md` era stato sovrascritto localmente con contenuto copiato da un altro progetto (l'app
+planner di Bancolini): regole roleGuard/admin-impersonation ("manutentore"), module map di Free
+Tasks / Communications / Gantt ("planner"), step di verifica browser con chrome-devtools-mcp, e un
+git workflow basato su `release/3` + GitLab — nulla di tutto ciò si applica a questo repo. Una
+sessione di grilling ha risolto le domande aperte prima della riscrittura (Asana convive con
+GitHub Issues invece di sostituirlo; changelog/ADR/release notes hanno una struttura a file per
+modifica solo in EN+IT, non ES; la verifica browser viene rimossa del tutto, dato che questo repo
+non ha un'app da testare nel browser).
+
+## Tracciamento
+GitHub Issue: non creata — `gh` non è autenticato in questo ambiente (richiede `gh auth login`).
+Task/subtask Asana: non creati — nessun tool MCP Asana era connesso in questa sessione. Entrambi
+vanno creati manualmente (o questa sessione va ri-eseguita una volta connessi i tool) per
+soddisfare la regola di tracciabilità che questa stessa modifica introduce.
+
+## Branch & Versione
+- **Branch:** `docs/rewrite-agents-for-thecore-auth`
+- **Versione:** `0.0.217`
+
+## File modificati
+| File | Modifica |
+|------|----------|
+| `AGENTS.md` | Ripristinato il contenuto specifico di thecore-auth (git workflow su main, tech stack/module map reali) che era stato sovrascritto con contenuto dell'app planner Bancolini; aggiunto tracciamento Asana (§2.6), processo di changelog (§2.9), processo di versionamento più ricco (§5), e lo split docs/en/adr + docs/it/adr (§6); rimossa del tutto la sezione di verifica browser |
+| `docs/it/AGENTS.md` | Traduzione italiana della stessa riscrittura |
+| `docs/es/AGENTS.md` | Traduzione spagnola della stessa riscrittura |
+| `docs/en/changelog/2026-07-29-0.0.217-docs-rewrite-agents-for-thecore-auth.md` | Questa entry |
+| `docs/it/changelog/2026-07-29-0.0.217-docs-rewrite-agents-for-thecore-auth.md` | Traduzione italiana di questa entry |
+| `CHANGELOG.md` | Creato l'indice master del changelog (non esisteva prima) e aggiunta la prima entry |
+
+## Modifiche tecniche
+Nessuna modifica al codice — è una modifica classificata `docs` secondo AGENTS.md §1.0, che tocca
+solo `AGENTS.md` e le sue traduzioni, oltre a stabilire la struttura di cartelle
+changelog/ADR/release-notes (`docs/en/{adr,changelog,releases}/` + `docs/it/{adr,changelog,releases}/`)
+che questa stessa modifica ora rende obbligatoria per il futuro.
+
+## Motivazione
+Tenere un `AGENTS.md` sbagliato avrebbe fatto sì che ogni futura sessione agente su questo repo
+seguisse regole per un codebase diverso da quello su cui sta operando (config di
+admin-impersonation, module map di Gantt/Free-Task, un branch `release/3` che qui non esiste). Le
+aggiunte strutturali più pesanti (Asana insieme a GitHub Issues, file di changelog per modifica,
+traduzione delle ADR) sono state adottate dal processo dell'app planner di Bancolini su
+raccomandazione della sessione di grilling — rispecchiando convenzioni di team già collaudate e in
+uso, invece di inventare un nuovo processo da zero — con un ambito linguistico più stretto (EN+IT,
+niente ES) dato che si tratta di documenti di processo ingegneristico interno, non della
+documentazione pubblica della libreria.


### PR DESCRIPTION
## Summary
- Restores thecore-auth's real facts in AGENTS.md (main-branch git workflow, real tech stack/module map) after it had been locally overwritten with Bancolini planner-app content (roleGuard/admin-impersonation, Free Tasks/Communications/Gantt module maps, chrome-devtools-mcp browser verification, release/3 + GitLab workflow)
- Adds Asana tracking (project "Sviluppo Sprint", always current sprint) alongside existing GitHub Issues
- Adds a per-change changelog system (docs/en/changelog/ + docs/it/changelog/) and moves ADRs to docs/en/adr/ + docs/it/adr/
- Adds a richer version-bump process (RELEASES.md in EN+IT + Asana release task)
- Removes the browser-verification section entirely — not applicable to this repo
- Translates the result into docs/it/AGENTS.md and docs/es/AGENTS.md

Closes #28

## Test plan
- [ ] Docs-only change — no tests apply
- [ ] Reviewer confirms EN/IT/ES AGENTS.md stay in sync