### PR TITLE
fix(auth): read fresh token via ref in window load handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,3 +8,4 @@ of every entry lives under `docs/it/changelog/`.
 
 - [docs-rewrite-agents-for-thecore-auth](docs/en/changelog/2026-07-29-0.0.217-docs-rewrite-agents-for-thecore-auth.md) — rewrite AGENTS.md (+ IT/ES translations) so it reflects thecore-auth instead of the Bancolini planner app it had been overwritten with
 - [use-environment-info-hook](docs/en/changelog/2026-07-29-0.0.217-use-environment-info-hook.md) — add internal `useEnvironmentInfo` hook for non-permission browser signals, plus the Vitest + React Testing Library setup this repo was missing
+- [fix-auth-provider-stale-load-listener](docs/en/changelog/2026-08-06-0.0.217-fix-auth-provider-stale-load-listener.md) — fix a stale-closure race where a login completed just before a delayed `window` `load` event on a hard reload would get silently reverted

--- a/docs/en/changelog/2026-08-06-0.0.217-fix-auth-provider-stale-load-listener.md
+++ b/docs/en/changelog/2026-08-06-0.0.217-fix-auth-provider-stale-load-listener.md
@@ -1,0 +1,89 @@
+# Fix stale-closure logout race in AuthProvider's window `load` listener
+
+## Context
+A bug report (received externally, forwarded by the user in conversation rather than filed as a
+GitHub Issue first) described a silent-logout race in a consumer app: after a hard reload on the
+login page followed by a successful login, the user ends up logged out under a UI that still looks
+logged in. Root cause, verified directly against this repo's source in
+`src/contexts/auth/AuthContext.jsx`: the `useEffect` that registers the native `window` `load`
+listener has an empty dependency array, so it runs once and captures `handleLoad` as a plain
+closure over the `token` value from the very first render (typically `null`, before any login). On
+a hard reload, the browser's `load` event is delayed until every asset finishes fetching over the
+network; if a user logs in successfully before that delayed event fires, the stale closure still
+sees the frozen `null` token when it finally runs, treats it as invalid, and calls `logout()` —
+wiping the token/user that were just legitimately set. A normal cached reload doesn't reproduce
+this because `load` fires almost immediately, before login has had a chance to complete.
+
+## Tracking
+- GitHub Issue: not created — `gh` is not authenticated in this session, so per AGENTS.md §2.5 this
+  is a **gap**: an issue referencing this fix should be filed before merge.
+- Asana: not created — the Asana MCP connector is not authorized in this session, so per AGENTS.md
+  §2.6 this is a **gap**: the main task + subtask should be created in "Sviluppo Sprint" (current
+  sprint) before merge.
+
+## Branch & Version
+- **Branch:** `fix/auth-provider-stale-load-listener`
+- **Version:** `0.0.217`
+
+## Files Changed
+| File | Change |
+|------|--------|
+| `src/contexts/auth/AuthContext.jsx` | `handleLoad` now reads the token from a `tokenRef` kept in sync on every render instead of from the closure captured when the `load` listener was registered; added the `tokenRef` and its sync effect |
+| `src/contexts/auth/AuthContext.test.jsx` | New test file: regression test reproducing the race (login completes, then a simulated deferred `load` event fires) plus a test for the legitimate case (token expires between mount and the deferred `load` event) |
+
+## Technical Changes
+```js
+// Kept in sync on every render — read by handleLoad instead of the `token`
+// closure variable, which the load-listener effect only captures once.
+const tokenRef = useRef(token);
+
+useEffect(() => {
+    tokenRef.current = token;
+}, [token]);
+
+const handleLoad = () => {
+    const currentToken = tokenRef.current;
+
+    if (checkTokenValidity(currentToken)) {
+        getTokenExpiry(currentToken);
+    } else {
+        logout();
+    }
+};
+
+// Unchanged: still registers/runs exactly once, still fires synchronously
+// if the page is already loaded, still cleans up the listener on unmount.
+useEffect(() => {
+    if (document.readyState === 'complete') {
+        handleLoad();
+    } else {
+        window.addEventListener('load', handleLoad);
+        return () => window.removeEventListener('load', handleLoad);
+    }
+}, []);
+```
+
+Audited every other `useEffect` in `AuthContext.jsx` for the same "closure captured once, never
+refreshed" pattern:
+- The mount-time token check (separate `useEffect([])` a few lines above) is **not** affected — it
+  runs synchronously at mount and evaluates the value it captures immediately, with no deferred
+  browser event in between. There is nothing for it to go stale against.
+- The autologin effect and the session/heartbeat-timer effect already declare real dependency
+  arrays (`[autoLogin, isAuthenticated, isLoggingIn, autoLoginError]` and `[token, timeoutToken]`
+  respectively) and re-run/re-schedule whenever those values change. No stale-closure risk there.
+
+Only the `load` listener was affected, because it is the only effect that both has empty deps *and*
+defers its callback to a native browser event with unpredictable timing.
+
+## Motivation
+A `ref` was chosen over the two other options the bug report suggested:
+- Re-deriving the check from `localStorage` directly inside `handleLoad` would have duplicated the
+  existing `useAuthStorage`/`useStorage` read path instead of reusing the state this provider
+  already tracks.
+- Making the effect depend on `[token]` (tearing down and re-adding the listener on every token
+  change) would change the effect's identity/timing semantics for no benefit — the fix only needs
+  `handleLoad` itself to observe the latest token, not the effect to re-run.
+
+The `tokenRef` pattern was already established in this codebase (`ConfigProvider`'s `fetchedRef` in
+`src/contexts/config/ConfigContext.jsx`), so it also keeps this fix consistent with existing
+conventions rather than introducing a new one.

--- a/docs/it/changelog/2026-08-06-0.0.217-fix-auth-provider-stale-load-listener.md
+++ b/docs/it/changelog/2026-08-06-0.0.217-fix-auth-provider-stale-load-listener.md
@@ -1,0 +1,94 @@
+# Fix della race di logout per closure stantia nel listener `window` `load` di AuthProvider
+
+## Contesto
+Una segnalazione di bug (ricevuta esternamente, riportata dall'utente in conversazione invece che
+aperta prima come GitHub Issue) descriveva una race di logout silenzioso in un'app consumer: dopo
+un hard reload sulla pagina di login seguito da un login riuscito, l'utente si ritrova disconnesso
+sotto una UI che appare ancora loggata. Causa radice, verificata direttamente sul sorgente di
+questo repo in `src/contexts/auth/AuthContext.jsx`: lo `useEffect` che registra il listener nativo
+`window` `load` ha un array di dipendenze vuoto, quindi viene eseguito una sola volta e cattura
+`handleLoad` come closure semplice sul valore di `token` del primissimo render (tipicamente
+`null`, prima di qualsiasi login). In un hard reload, l'evento `load` del browser viene ritardato
+finché ogni asset non ha finito di essere scaricato dalla rete; se un utente effettua login con
+successo prima che quell'evento ritardato scatti, la closure stantia vede comunque il token
+`null` congelato quando viene finalmente eseguita, lo considera non valido e chiama `logout()` —
+cancellando il token/utente appena impostati legittimamente. Un reload normale (con cache) non
+riproduce il problema perché `load` scatta quasi immediatamente, prima che il login abbia avuto
+modo di completarsi.
+
+## Tracking
+- GitHub Issue: non creata — `gh` non è autenticato in questa sessione, quindi per AGENTS.md §2.5
+  questo è un **gap**: prima del merge va aperta una issue che referenzi questo fix.
+- Asana: non creato — il connettore MCP di Asana non è autorizzato in questa sessione, quindi per
+  AGENTS.md §2.6 questo è un **gap**: prima del merge vanno creati il main task + subtask in
+  "Sviluppo Sprint" (sprint corrente).
+
+## Branch & Versione
+- **Branch:** `fix/auth-provider-stale-load-listener`
+- **Versione:** `0.0.217`
+
+## File modificati
+| File | Modifica |
+|------|----------|
+| `src/contexts/auth/AuthContext.jsx` | `handleLoad` ora legge il token da un `tokenRef` sincronizzato ad ogni render invece che dalla closure catturata al momento della registrazione del listener `load`; aggiunti il `tokenRef` e il relativo effect di sincronizzazione |
+| `src/contexts/auth/AuthContext.test.jsx` | Nuovo file di test: test di regressione che riproduce la race (il login si completa, poi viene simulato un evento `load` ritardato) più un test per il caso legittimo (il token scade tra il mount e l'evento `load` ritardato) |
+
+## Modifiche tecniche
+```js
+// Sincronizzato ad ogni render — letto da handleLoad invece della variabile
+// `token` di closure, che l'effect del load-listener cattura una sola volta.
+const tokenRef = useRef(token);
+
+useEffect(() => {
+    tokenRef.current = token;
+}, [token]);
+
+const handleLoad = () => {
+    const currentToken = tokenRef.current;
+
+    if (checkTokenValidity(currentToken)) {
+        getTokenExpiry(currentToken);
+    } else {
+        logout();
+    }
+};
+
+// Invariato: continua a registrarsi/eseguirsi esattamente una volta, continua
+// a scattare in modo sincrono se la pagina è già caricata, continua a
+// rimuovere il listener allo smontaggio.
+useEffect(() => {
+    if (document.readyState === 'complete') {
+        handleLoad();
+    } else {
+        window.addEventListener('load', handleLoad);
+        return () => window.removeEventListener('load', handleLoad);
+    }
+}, []);
+```
+
+Verificati tutti gli altri `useEffect` di `AuthContext.jsx` per lo stesso pattern "closure
+catturata una volta, mai aggiornata":
+- Il controllo del token al mount (uno `useEffect([])` separato poche righe sopra) **non** è
+  affetto — viene eseguito in modo sincrono al mount e valuta il valore che cattura
+  immediatamente, senza nessun evento browser differito nel mezzo. Non c'è nulla rispetto a cui
+  possa diventare stantio.
+- L'effect di autologin e quello dei timer di sessione/heartbeat dichiarano già array di
+  dipendenze reali (rispettivamente `[autoLogin, isAuthenticated, isLoggingIn, autoLoginError]` e
+  `[token, timeoutToken]`) e si ri-eseguono/ri-pianificano ogni volta che quei valori cambiano.
+  Nessun rischio di closure stantia lì.
+
+Solo il listener `load` era affetto, perché è l'unico effect che ha sia dipendenze vuote *sia*
+differisce la propria callback a un evento nativo del browser con timing imprevedibile.
+
+## Motivazione
+Un `ref` è stato scelto rispetto alle altre due opzioni suggerite dalla segnalazione:
+- Ri-derivare il controllo leggendo direttamente da `localStorage` dentro `handleLoad` avrebbe
+  duplicato il percorso di lettura già esistente in `useAuthStorage`/`useStorage`, invece di
+  riusare lo stato che questo provider già traccia.
+- Far dipendere l'effect da `[token]` (smontando e ri-registrando il listener ad ogni cambio di
+  token) avrebbe cambiato l'identità/il timing dell'effect senza alcun beneficio — il fix richiede
+  solo che `handleLoad` osservi il token più recente, non che l'effect si ri-esegua.
+
+Il pattern `tokenRef` era già presente in questo codebase (`fetchedRef` di `ConfigProvider` in
+`src/contexts/config/ConfigContext.jsx`), quindi mantiene questo fix coerente con le convenzioni
+esistenti invece di introdurne una nuova.

--- a/src/contexts/auth/AuthContext.jsx
+++ b/src/contexts/auth/AuthContext.jsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, useEffect, useState } from "react";
+import { createContext, useContext, useEffect, useRef, useState } from "react";
 import jwt_decode from 'jwt-decode';
 import { useNavigate } from "react-router-dom";
 import { useConfig } from "../config/ConfigContext.jsx";
@@ -20,6 +20,10 @@ const AuthProvider = ({ children }) => {
 
     const [isAuthenticated, setIsAuthenticated] = useState(null);
     const [timeoutToken, setTimeoutToken] = useState();
+    // Il listener 'load' viene registrato una sola volta (deps []) e non si
+    // riaggancia mai: legge il token da questo ref, sempre aggiornato, invece
+    // che dalla variabile `token` chiusa nella closure del primo render.
+    const tokenRef = useRef(token);
     const [sessionTimeout, setSessionTimeout] = useState();
     const [isLoggingIn, setIsLoggingIn] = useState(false);
     const [autoLoginError, setAutoLoginError] = useState(null);
@@ -214,18 +218,27 @@ const AuthProvider = ({ children }) => {
 
     const handleLoad = () => {
 
+        // Legge il token corrente dal ref, non dalla closure del render in
+        // cui il listener è stato registrato (vedi tokenRef sopra).
+        const currentToken = tokenRef.current;
+
         // Controllo che il token sia valido
-        if (checkTokenValidity(token)) {
+        if (checkTokenValidity(currentToken)) {
             if (tokenLog) console.log('[Auth]: Ricarico pagina → controllo scadenza token');
 
             // Aggiorna gli state dei timer e heartbeat
-            getTokenExpiry(token);
+            getTokenExpiry(currentToken);
         } else {
             // Token scaduto o non valido → logout
             if (tokenLog) console.warn('[Auth]: Token non valido al reload, eseguo logout');
             logout();
         }
     };
+
+    // Mantiene tokenRef sincronizzato con il token corrente ad ogni render.
+    useEffect(() => {
+        tokenRef.current = token;
+    }, [token]);
 
     // useEffect per il controllo del Token
     useEffect(() => {

--- a/src/contexts/auth/AuthContext.test.jsx
+++ b/src/contexts/auth/AuthContext.test.jsx
@@ -1,0 +1,124 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { AuthProvider, useAuth } from "./AuthContext";
+import { fetchAxiosConfig } from "../../api/axiosInstance.js";
+import jwt_decode from "jwt-decode";
+
+vi.mock("react-router-dom", () => ({
+    useNavigate: () => vi.fn(),
+}));
+
+vi.mock("../config/ConfigContext.jsx", () => ({
+    useConfig: () => ({
+        heartbeatEndpoint: "/heartbeat",
+        firstPrivatePath: "/dashboard/",
+        infiniteSession: false,
+        timeDeducted: 0,
+        authenticatedEndpoint: "/login",
+        autoLogin: false,
+        setCurrentDate: vi.fn(),
+        isDebug: false,
+        backendToken: null,
+        useCustomLoginTimeout: false,
+        stopLoaderOnFinish: true,
+        customLoginTimeout: 0,
+        tokenLog: false,
+        timerInfiniteSession: undefined,
+    }),
+}));
+
+vi.mock("../loading/LoadingContext.jsx", () => ({
+    useLoading: () => ({ setIsLoading: vi.fn(), showLoadingFor: vi.fn() }),
+}));
+
+vi.mock("../alert/AlertContext.jsx", () => ({
+    useAlert: () => ({ setShowAlert: vi.fn(), activeAlert: vi.fn() }),
+}));
+
+vi.mock("../../api/axiosInstance.js", () => ({
+    fetchAxiosConfig: vi.fn(),
+}));
+
+vi.mock("jwt-decode", () => ({
+    default: vi.fn(),
+}));
+
+const defineReadyState = (value) => {
+    Object.defineProperty(document, "readyState", { value, configurable: true });
+};
+
+describe("AuthProvider - window 'load' listener", () => {
+    beforeEach(() => {
+        localStorage.clear();
+        defineReadyState("loading");
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+        defineReadyState("complete");
+    });
+
+    it("does not revert a login that completes before the deferred window load event fires", async () => {
+        jwt_decode.mockImplementation((token) => {
+            if (token === "fresh-token") {
+                return { exp: Math.floor(Date.now() / 1000) + 3600 };
+            }
+            throw new Error(`unexpected token passed to jwt_decode: ${token}`);
+        });
+
+        fetchAxiosConfig.mockResolvedValue({
+            post: vi.fn().mockResolvedValue({
+                headers: { token: "fresh-token" },
+                data: { id: 42, name: "Mario" },
+            }),
+            get: vi.fn(),
+        });
+
+        // AuthProvider mounts here, while `document.readyState` is still
+        // "loading" (simulating the slow hard-reload window before the
+        // native `load` event fires) — this registers the listener instead
+        // of running the check synchronously.
+        const { result } = renderHook(() => useAuth(), { wrapper: AuthProvider });
+
+        await act(async () => {
+            await result.current.login(null, { username: "mario", password: "secret" });
+        });
+
+        expect(result.current.isAuthenticated).toBe(true);
+        expect(JSON.parse(localStorage.getItem("accessToken"))).toBe("fresh-token");
+
+        // The deferred native `load` event finally fires, AFTER the login
+        // already completed successfully.
+        act(() => {
+            window.dispatchEvent(new Event("load"));
+        });
+
+        expect(result.current.isAuthenticated).toBe(true);
+        expect(JSON.parse(localStorage.getItem("accessToken"))).toBe("fresh-token");
+    });
+
+    it("still logs out via the load listener when the token becomes invalid before the deferred load event fires", () => {
+        localStorage.setItem("accessToken", JSON.stringify("token-that-will-expire"));
+
+        let tokenIsValid = true;
+        jwt_decode.mockImplementation(() => {
+            const currentTime = Math.floor(Date.now() / 1000);
+            return { exp: tokenIsValid ? currentTime + 3600 : currentTime - 1 };
+        });
+
+        const { result } = renderHook(() => useAuth(), { wrapper: AuthProvider });
+
+        // Valid at mount time -> the mount-time check must NOT log out.
+        expect(result.current.isAuthenticated).toBe(true);
+
+        // Token expires while the (slow) hard reload is still fetching assets.
+        tokenIsValid = false;
+
+        act(() => {
+            window.dispatchEvent(new Event("load"));
+        });
+
+        expect(result.current.isAuthenticated).toBe(false);
+        expect(localStorage.getItem("accessToken")).toBeNull();
+    });
+});


### PR DESCRIPTION
## Summary
- `AuthProvider`'s `window` `load` listener is registered once (`useEffect([])`) and closed over the `token` value from the very first render, so a login completing before a delayed `load` event (hard reload) gets silently reverted by a stale-closure `logout()` call.
- `handleLoad` now reads the token from a `tokenRef` kept in sync every render instead of the closure variable. Every other `useEffect` in this file was audited for the same pattern (see changelog entry) — none had it.

Closes #33

## Test plan
- [x] New regression test: login completes, then a simulated deferred `load` event fires → `isAuthenticated`/stored token must remain valid (fails on the pre-fix code, passes after).
- [x] New test for the legitimate case: token expires between mount and the deferred `load` event → logout must still happen.
- [x] Full existing suite passes (`npx vitest run`, 17/17).
- [x] `eslint` on changed files: no new warnings.

## Tracking gaps
- Asana task/subtask not created — the Asana MCP connector is not authorized in this session. Should be created in "Sviluppo Sprint" (current sprint) before merge, per AGENTS.md §2.6.

## Note on base branch
This PR targets `feature/use-environment-info-hook` (not `main`) because it was branched from it to reuse the Vitest + React Testing Library harness, which isn't on `main` yet. It should merge after (or together with) that branch's own PR (#32) into `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)